### PR TITLE
use leaflet-control-geocoder to provide a geocoder on the team edit map

### DIFF
--- a/app/db/knexfile.js
+++ b/app/db/knexfile.js
@@ -10,10 +10,10 @@ if (!process.env.NODE_ENV) {
 if (process.env.DSN) {
   DATABASE_URL = process.env.DSN
 } else {
+  pg.defaults.ssl = false
   if (process.env.NODE_ENV === 'development') {
     DATABASE_URL = 'postgres://postgres@localhost/osm-teams'
   } else if (process.env.NODE_ENV === 'test') {
-    pg.defaults.ssl = false
     DATABASE_URL = 'postgres://postgres@localhost/osm-teams-test'
   }
 }

--- a/components/edit-team-form.js
+++ b/components/edit-team-form.js
@@ -15,7 +15,7 @@ export default function EditTeamForm ({ initialValues, onSubmit }) {
             <h2>Details</h2>
             <div className='form-control'>
               <label htmlFor='name'>Name<span className='red'>*</span></label>
-              <Field type='text' name='name' required requiredStar className={errors.name ? 'ba b--red' : ''} />
+              <Field type='text' name='name' required className={errors.name ? 'ba b--red' : ''} />
               {errors.name && (
                 <div>
                   {errors.name}

--- a/components/form-map.js
+++ b/components/form-map.js
@@ -24,7 +24,6 @@ export default class FormMap extends Component {
 
       this.geocoder.on('markgeocode', (e) => {
         const bbox = e.geocode.bbox
-        console.log('this.map', this.map)
         this.map.current.leafletElement.fitBounds(bbox)
       })
 

--- a/components/form-map.js
+++ b/components/form-map.js
@@ -6,6 +6,7 @@ import Geocoder from 'leaflet-control-geocoder'
 export default class FormMap extends Component {
   constructor (props) {
     super(props)
+    this.map = React.createRef()
     this.state = {
       zoom: 15
     }
@@ -24,10 +25,10 @@ export default class FormMap extends Component {
       this.geocoder.on('markgeocode', (e) => {
         const bbox = e.geocode.bbox
         console.log('this.map', this.map)
-        this.map.leafletElement.fitBounds(bbox)
+        this.map.current.leafletElement.fitBounds(bbox)
       })
 
-      this.map.leafletElement.addControl(this.geocoder)
+      this.map.current.leafletElement.addControl(this.geocoder)
     }
   }
 
@@ -40,7 +41,7 @@ export default class FormMap extends Component {
         center={center}
         zoom={this.state.zoom}
         style={this.props.style}
-        ref={(map) => { this.map = map }}
+        ref={this.map}
         onViewportChange={({ center, zoom }) => {
           let toGeojson = `{
           "type": "Point",

--- a/components/form-map.js
+++ b/components/form-map.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import { Map, CircleMarker, TileLayer } from 'react-leaflet'
 import { reverse } from 'ramda'
+import Geocoder from 'leaflet-control-geocoder'
 
 export default class FormMap extends Component {
   constructor (props) {
@@ -14,20 +15,41 @@ export default class FormMap extends Component {
     this.setState({ zoom })
   }
 
+  componentDidMount () {
+    if (this.map && !this.geocoder) {
+      this.geocoder = new Geocoder({
+        defaultMarkGeocode: false
+      })
+
+      this.geocoder.on('markgeocode', (e) => {
+        const bbox = e.geocode.bbox
+        console.log('this.map', this.map)
+        this.map.leafletElement.fitBounds(bbox)
+      })
+
+      this.map.leafletElement.addControl(this.geocoder)
+    }
+  }
+
   render () {
     let centerGeojson = this.props.value || '{ "type": "Point", "coordinates": [-77.03637, 38.89511] }'
     let center = reverse(JSON.parse(centerGeojson).coordinates)
 
     return (
-      <Map center={center} zoom={this.state.zoom} style={this.props.style}
+      <Map
+        center={center}
+        zoom={this.state.zoom}
+        style={this.props.style}
+        ref={(map) => { this.map = map }}
         onViewportChange={({ center, zoom }) => {
-          let toGeojson = `{ 
-          "type": "Point", 
+          let toGeojson = `{
+          "type": "Point",
           "coordinates": [${center[1]},${center[0]}]
         }`
           this.setZoom(zoom)
           this.props.onChange(this.props.name, toGeojson)
-        }} >
+        }}
+      >
         <TileLayer
           attribution='&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
           url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "knex": "^0.16.3",
     "knex-postgis": "^0.8.1",
     "leaflet": "^1.5.1",
+    "leaflet-control-geocoder": "^1.9.0",
     "next": "^8.0.1",
     "node-fetch": "^2.3.0",
     "passport-light": "^1.0.1",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -54,7 +54,7 @@ class OSMHydra extends App {
           <link rel='stylesheet' href='https://unpkg.com/leaflet@1.5.1/dist/leaflet.css'
             integrity='sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ=='
             crossOrigin='' />
-          <link rel="stylesheet" href="https://unpkg.com/leaflet-control-geocoder/dist/Control.Geocoder.css" />
+          <link rel='stylesheet' href='https://unpkg.com/leaflet-control-geocoder/dist/Control.Geocoder.css' />
           <link rel='shortcut icon' href='/static/favicon.ico' />
           <link rel='icon' type='image/png' href='/static/favicon.png' />
         </Head>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -53,7 +53,8 @@ class OSMHydra extends App {
           <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Inconsolata:400,700|Work+Sans:400,700&display=swap' />
           <link rel='stylesheet' href='https://unpkg.com/leaflet@1.5.1/dist/leaflet.css'
             integrity='sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ=='
-            crossorigin='' />
+            crossOrigin='' />
+          <link rel="stylesheet" href="https://unpkg.com/leaflet-control-geocoder/dist/Control.Geocoder.css" />
           <link rel='shortcut icon' href='/static/favicon.ico' />
           <link rel='icon' type='image/png' href='/static/favicon.png' />
         </Head>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5497,6 +5497,13 @@ launch-editor@2.2.1:
     chalk "^2.3.0"
     shell-quote "^1.6.1"
 
+leaflet-control-geocoder@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/leaflet-control-geocoder/-/leaflet-control-geocoder-1.9.0.tgz#d837569de7762953cd4f9543850602bab9f82230"
+  integrity sha512-yY6v8wly5Z+S4avTedgEGlDiW1HNPUS+1Eggus0k8UFxoSg7doZZv23T/1wQjix5hJZBEnlEgyHv4HAW1D8W+A==
+  optionalDependencies:
+    open-location-code "^1.0.0"
+
 leaflet@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.5.1.tgz#9afb9d963d66c870066b1342e7a06f92840f46bf"
@@ -6525,6 +6532,11 @@ onetime@^2.0.0:
   integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
   dependencies:
     mimic-fn "^1.0.0"
+
+open-location-code@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/open-location-code/-/open-location-code-1.0.3.tgz#5ea1a34ee5221c6cafa04392e1bd906fd7488f7e"
+  integrity sha1-XqGjTuUiHGyvoEOS4b2Qb9dIj34=
 
 opn@^3.0.2:
   version "3.0.3"


### PR DESCRIPTION
this pr:
- adds leaflet-control-geocoder
- lets users geocode on the team edit map to find places easier

this pr also makes a few little fixes that can be reverted if needed:
- moves `pg.defaults.ssl = false` to a line that works for both development & test cases. there might be a better way to handle this, but in the case where the node env is development and the database url env isn't being set `pg.defaults.ssl = true` doesn't work.
- removes an unneeded attribute in the team edit form
- uses `crossOrigin` instead of `crossorigin` in a stylesheet link because apparently that was throwing an error in react

currently nominatim is being used as the geocoder. we might want to make that configurable.

closes #57 