### PR TITLE
authenticated users can join public teams

### DIFF
--- a/app/manage/index.js
+++ b/app/manage/index.js
@@ -3,10 +3,20 @@ const expressPino = require('express-pino-logger')
 
 const { getClients, createClient, deleteClient } = require('./client')
 const { login, loginAccept, logout } = require('./login')
-const { listTeams, createTeam, getTeam, updateTeam, destroyTeam, addMember, removeMember, updateMembers } = require('./teams')
 const { can } = require('./permissions')
 const sessionMiddleware = require('./sessions')
 const logger = require('../lib/logger')
+const {
+  listTeams,
+  createTeam,
+  getTeam,
+  updateTeam,
+  destroyTeam,
+  addMember,
+  removeMember,
+  updateMembers,
+  joinTeam
+} = require('./teams')
 
 /**
  * The manageRouter handles all routes related to the first party
@@ -55,6 +65,7 @@ function manageRouter (nextApp) {
   router.put('/api/teams/add/:id/:osmId', can('team:update'), addMember)
   router.put('/api/teams/remove/:id/:osmId', can('team:update'), removeMember)
   router.patch('/api/teams/:id/members', can('team:update'), updateMembers)
+  router.put('/api/teams/:id/join', can('team:join'), joinTeam)
 
   /**
    * Page renders

--- a/app/manage/permissions/index.js
+++ b/app/manage/permissions/index.js
@@ -10,7 +10,8 @@ const teamPermissions = {
   'team:create': require('./create-team'),
   'team:update': require('./update-team'),
   'team:view': require('./view-team'),
-  'team:delete': require('./delete-team')
+  'team:delete': require('./delete-team'),
+  'team:join': require('./join-team')
 }
 
 const clientPermissions = {

--- a/app/manage/permissions/join-team.js
+++ b/app/manage/permissions/join-team.js
@@ -1,0 +1,18 @@
+const { isPublic, isMember } = require('../../lib/team')
+
+/**
+ * team:join
+ *
+ * To join a team, the team must be public
+ *
+ * @param {string} uid user id
+ * @param {Object} params request parameters
+ * @returns {boolean} can the request go through?
+ */
+async function joinTeam (uid, { id }) {
+  const publicTeam = await isPublic(id)
+  const member = await isMember(id, uid)
+  return publicTeam && !member
+}
+
+module.exports = joinTeam

--- a/app/manage/teams.js
+++ b/app/manage/teams.js
@@ -151,6 +151,27 @@ async function removeMember (req, reply) {
   }
 }
 
+async function joinTeam (req, reply) {
+  const { id } = req.params
+  const osmId = reply.locals.user_id
+
+  if (!id) {
+    return reply.boom.badRequest('team id is required')
+  }
+
+  if (!osmId) {
+    return reply.boom.badRequest('osm id is required')
+  }
+
+  try {
+    await team.addMember(id, osmId)
+    return reply.sendStatus(200)
+  } catch (err) {
+    console.log(err)
+    return reply.boom.badRequest()
+  }
+}
+
 module.exports = {
   listTeams,
   getTeam,
@@ -159,5 +180,6 @@ module.exports = {
   destroyTeam,
   addMember,
   updateMembers,
-  removeMember
+  removeMember,
+  joinTeam
 }

--- a/app/tests/permissions/join-team.test.js
+++ b/app/tests/permissions/join-team.test.js
@@ -1,0 +1,72 @@
+const test = require('ava')
+const db = require('../../db')
+const path = require('path')
+const hydra = require('../../lib/hydra')
+const sinon = require('sinon')
+
+const team = require('../../lib/team')
+
+const migrationsDirectory = path.join(__dirname, '..', '..', 'db', 'migrations')
+
+let agent
+test.before(async (t) => {
+  const conn = await db()
+  await conn.migrate.latest({ directory: migrationsDirectory })
+
+  // seed
+  await conn('users').insert({ id: 100 })
+  await conn('users').insert({ id: 101 })
+
+  t.context.publicTeam = await team.create({ name: 'public team' }, 100)
+  t.context.privateTeam = await team.create({ name: 'private team', privacy: 'private' }, 100)
+
+  // stub hydra introspect
+  let introspectStub = sinon.stub(hydra, 'introspect')
+  introspectStub.withArgs('validToken').returns({
+    active: true,
+    sub: '100'
+  })
+  introspectStub.withArgs('differentUser').returns({
+    active: true,
+    sub: '101'
+  })
+  introspectStub.withArgs('invalidToken').returns({ active: false })
+
+  agent = require('supertest').agent(await require('../../index')())
+})
+
+test.after.always(async () => {
+  const conn = await db()
+  await conn.migrate.rollback({ directory: migrationsDirectory })
+  conn.destroy()
+})
+
+test('a user can join a public team', async t => {
+  const team = t.context.publicTeam
+  let res = await agent.put(`/api/teams/${team.id}/join`)
+    .set('Authorization', `Bearer differentUser`)
+  t.is(res.status, 200)
+})
+
+test('a user cannot join a private team', async t => {
+  const team = t.context.privateTeam
+  let res = await agent.put(`/api/teams/${team.id}/join`)
+    .set('Authorization', `Bearer differentUser`)
+  t.is(res.status, 401)
+})
+
+test('a user cannot join a team they are already in', async t => {
+  const team = t.context.publicTeam
+  let res = await agent.put(`/api/teams/${team.id}/join`)
+    .set('Authorization', `Bearer validToken`)
+  t.is(res.status, 401)
+})
+
+test('a user must be authenticated to join a team', async t => {
+  const team = t.context.publicTeam
+  let invalidToken = await agent.put(`/api/teams/${team.id}/join`)
+    .set('Authorization', `Bearer invalidToken`)
+  t.is(invalidToken.status, 401)
+  let unauthenticated = await agent.put(`/api/teams/${team.id}/join`)
+  t.is(unauthenticated.status, 401)
+})

--- a/lib/teams-api.js
+++ b/lib/teams-api.js
@@ -132,3 +132,19 @@ export async function addMember (id, osmId) {
 export async function removeMember (id, osmId) {
   return updateMembers(id, [], [osmId])
 }
+
+/**
+ * joinTeam
+ * Let current user join team
+ *
+ * @param id - Team id
+ * @returns {Response}
+ */
+export async function joinTeam (id) {
+  return fetch(join(URL, `${id}`, 'join'), {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8'
+    }
+  })
+}

--- a/pages/team.js
+++ b/pages/team.js
@@ -11,7 +11,7 @@ import Table from '../components/table'
 import AddMemberForm from '../components/add-member-form'
 import theme from '../styles/theme'
 
-import { getTeam, addMember, removeMember } from '../lib/teams-api'
+import { getTeam, addMember, removeMember, joinTeam } from '../lib/teams-api'
 
 const Map = dynamic(() => import('../components/team-map'), { ssr: false })
 
@@ -50,6 +50,21 @@ export default class Team extends Component {
         error: e,
         team: null,
         loading: false
+      })
+    }
+  }
+
+  async joinTeam () {
+    const { id, user } = this.props
+    const osmId = user.uid
+
+    try {
+      await joinTeam(id, osmId)
+      await this.getTeam(id)
+    } catch (e) {
+      console.error(e)
+      this.setState({
+        error: e
       })
     }
   }
@@ -151,25 +166,26 @@ export default class Team extends Component {
 
     if (!team) return null
 
-    // Check if the user is a moderator for this team
+    const userId = this.props.user.uid
+    const members = map(prop('id'), team.members)
     const moderators = map(prop('osm_id'), team.moderators)
-    const isUserModerator = contains(parseInt(this.props.user.uid), moderators)
 
-    let members = team.members
+    // TODO: moderators is an array of ints while members are an array of strings. fix this.
+    const isUserModerator = contains(parseInt(userId), moderators)
+    const isMember = contains(userId, members)
 
     const columns = [
       { key: 'id' },
       { key: 'name' }
     ]
 
+    let memberRows = team.members
     if (isUserModerator) {
       columns.push({ key: 'actions' })
 
-      members = members.map((member) => {
-        if (isUserModerator) {
-          member.actions = (row, index, columns) => {
-            return this.renderActions(row, index, columns, isUserModerator)
-          }
+      memberRows = memberRows.map((member) => {
+        member.actions = (row, index, columns) => {
+          return this.renderActions(row, index, columns, isUserModerator)
         }
 
         return member
@@ -181,6 +197,8 @@ export default class Team extends Component {
         <div className='page__heading'>
           <h2>{team.name}</h2>
           { isUserModerator ? <Button variant='primary' href={`/teams/${team.id}/edit`}>Edit Team</Button> : <div /> }
+          { userId && !isMember ? <Button variant='primary' onClick={() => this.joinTeam()}>Join Team</Button> : <div /> }
+          { !userId ? <Button variant='primary' href={`/login`}>Sign in to join team</Button> : <div /> }
         </div>
         <div className='team__details'>
           <Card>
@@ -211,7 +229,7 @@ export default class Team extends Component {
               </div>
             </div>
             <Table
-              rows={members}
+              rows={memberRows}
               columns={columns}
             />
           </Section>

--- a/pages/team.js
+++ b/pages/team.js
@@ -196,7 +196,7 @@ export default class Team extends Component {
       <article className='inner page team'>
         <div className='page__heading'>
           <h2>{team.name}</h2>
-          { isUserModerator ? <Button variant='primary' href={`/teams/${team.id}/edit`}>Edit Team</Button> : <div /> }
+          { isUserModerator ? <Button variant='primary' href={`/teams/${team.id}/edit`}>Edit Team</Button> : ''}
           { userId && !isMember ? <Button variant='primary' onClick={() => this.joinTeam()}>Join Team</Button> : <div /> }
           { !userId ? <Button variant='primary' href={`/login`}>Sign in to join team</Button> : '' }
         </div>

--- a/pages/team.js
+++ b/pages/team.js
@@ -198,7 +198,7 @@ export default class Team extends Component {
           <h2>{team.name}</h2>
           { isUserModerator ? <Button variant='primary' href={`/teams/${team.id}/edit`}>Edit Team</Button> : <div /> }
           { userId && !isMember ? <Button variant='primary' onClick={() => this.joinTeam()}>Join Team</Button> : <div /> }
-          { !userId ? <Button variant='primary' href={`/login`}>Sign in to join team</Button> : <div /> }
+          { !userId ? <Button variant='primary' href={`/login`}>Sign in to join team</Button> : '' }
         </div>
         <div className='team__details'>
           <Card>

--- a/pages/team.js
+++ b/pages/team.js
@@ -197,7 +197,7 @@ export default class Team extends Component {
         <div className='page__heading'>
           <h2>{team.name}</h2>
           { isUserModerator ? <Button variant='primary' href={`/teams/${team.id}/edit`}>Edit Team</Button> : ''}
-          { userId && !isMember ? <Button variant='primary' onClick={() => this.joinTeam()}>Join Team</Button> : <div /> }
+          { userId && !isMember ? <Button variant='primary' onClick={() => this.joinTeam()}>Join Team</Button> : '' }
           { !userId ? <Button variant='primary' href={`/login`}>Sign in to join team</Button> : '' }
         </div>
         <div className='team__details'>


### PR DESCRIPTION
closes #80 

This adds a button for authenticated users to the team view page letting them join the team if they are not already in it.

It also adds a `Sign in to join team` button if the user has not yet logged in.

All this is accomplished with an endpoint at `/api/teams/:id/join` that takes the user id of the current session and adds them to the team if allowed by the `team:join` permission. This is distinct from the endpoints for adding/updating members because it is assumed those are requested by team moderators. I think it makes sense for `join` to be separate.

If the user signs in with the `Sign in to join team` button it does not redirect them back to the team page. I think that would be an important thing to add. I am not yet sure how to accomplish that with this login flow, though. It might be best to make an issue for that and revisit it later.