### PR TITLE
Team moderators can assign other users as moderators

### DIFF
--- a/app/db/knexfile.js
+++ b/app/db/knexfile.js
@@ -1,6 +1,3 @@
-const pg = require('pg')
-pg.defaults.ssl = true
-
 let DATABASE_URL
 
 if (!process.env.NODE_ENV) {
@@ -10,11 +7,10 @@ if (!process.env.NODE_ENV) {
 if (process.env.DSN) {
   DATABASE_URL = process.env.DSN
 } else {
-  pg.defaults.ssl = false
   if (process.env.NODE_ENV === 'development') {
-    DATABASE_URL = 'postgres://postgres@localhost/osm-teams'
+    DATABASE_URL = 'postgres://postgres@localhost/osm-teams?ssl=false'
   } else if (process.env.NODE_ENV === 'test') {
-    DATABASE_URL = 'postgres://postgres@localhost/osm-teams-test'
+    DATABASE_URL = 'postgres://postgres@localhost/osm-teams-test?ssl=false'
   }
 }
 

--- a/app/db/knexfile.js
+++ b/app/db/knexfile.js
@@ -8,9 +8,9 @@ if (process.env.DSN) {
   DATABASE_URL = process.env.DSN
 } else {
   if (process.env.NODE_ENV === 'development') {
-    DATABASE_URL = 'postgres://postgres@localhost/osm-teams?ssl=false'
+    DATABASE_URL = 'postgres://postgres@localhost/osm-teams?sslmode=disable'
   } else if (process.env.NODE_ENV === 'test') {
-    DATABASE_URL = 'postgres://postgres@localhost/osm-teams-test?ssl=false'
+    DATABASE_URL = 'postgres://postgres@localhost/osm-teams-test?sslmode=disable'
   }
 }
 

--- a/app/db/migrations/20200130150202_team-moderator-unique.js
+++ b/app/db/migrations/20200130150202_team-moderator-unique.js
@@ -1,0 +1,26 @@
+/* Add a unique constraint on the moderator table so the same team_id and
+osm_id cannot be added more than once. */
+
+const tableName = 'moderator'
+const columns = ['team_id', 'osm_id']
+const keyName = 'moderator_team_id_osm_id_key'
+
+// in postgresql: `alter table moderator add unique (team_id, osm_id);`
+// creates unique constraint named "moderator_team_id_osm_id_key"
+exports.up = async (knex) => {
+  try {
+    await knex.schema.alterTable(tableName, table => table.unique(columns, keyName))
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+// in posgresql: `alter table moderator drop constraint moderator_team_id_osm_id_key;`
+// drops the unique constraint.
+exports.down = async (knex) => {
+  try {
+    await knex.schema.alterTable(tableName, table => table.dropUnique(columns, keyName))
+  } catch (e) {
+    console.error(e)
+  }
+}

--- a/app/db/migrations/20200130155125_team-member-unique.js
+++ b/app/db/migrations/20200130155125_team-member-unique.js
@@ -1,0 +1,26 @@
+/* Add a unique constraint on the member table so the same team_id and
+osm_id cannot be added more than once. */
+
+const tableName = 'member'
+const columns = ['team_id', 'osm_id']
+const keyName = 'member_team_id_osm_id_key'
+
+// in postgresql: `alter table member add unique (team_id, osm_id);`
+// creates unique constraint named "member_team_id_osm_id_key"
+exports.up = async (knex) => {
+  try {
+    await knex.schema.alterTable(tableName, table => table.unique(columns, keyName))
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+// in posgresql: `alter table member drop constraint member_team_id_osm_id_key;`
+// drops the unique constraint.
+exports.down = async (knex) => {
+  try {
+    await knex.schema.alterTable(tableName, table => table.dropUnique(columns, keyName))
+  } catch (e) {
+    console.error(e)
+  }
+}

--- a/app/lib/team.js
+++ b/app/lib/team.js
@@ -236,6 +236,9 @@ async function removeMember (teamId, osmId) {
  */
 async function assignModerator (teamId, osmId) {
   const conn = await db()
+  if (!await isMember(teamId, osmId)) {
+    throw new Error('cannot assign osmId to be moderator because they are not a team member yet.')
+  }
   return unpack(conn('moderator').insert({ team_id: teamId, osm_id: osmId }))
 }
 

--- a/app/lib/team.js
+++ b/app/lib/team.js
@@ -277,7 +277,7 @@ async function isModerator (teamId, osmId) {
   if (!osmId) throw new Error('osm id is required as second argument')
   const conn = await db()
   const [{ count }] = await conn('moderator').where({ team_id: teamId, osm_id: osmId }).count()
-  return count > 0
+  return parseInt(count) > 0
 }
 
 /**
@@ -291,7 +291,7 @@ async function isMember (teamId, osmId) {
   if (!osmId) throw new Error('osm id is required as second argument')
   const conn = await db()
   const [{ count }] = await conn('member').where({ team_id: teamId, osm_id: osmId }).count()
-  return count > 0
+  return parseInt(count) > 0
 }
 
 /**

--- a/app/lib/team.js
+++ b/app/lib/team.js
@@ -220,12 +220,16 @@ async function addMember (teamId, osmId) {
 }
 
 /**
-* Remove an osm user as a team member
+* Remove an osm user as a team member. Removes moderator as side-effect when necessary.
 * @param {int} teamId - team id
 * @param {int} osmId - osm id
 * @return {promise}
 **/
 async function removeMember (teamId, osmId) {
+  const isMod = await isModerator(teamId, osmId)
+  if (isMod) {
+    await removeModerator(teamId, osmId)
+  }
   return updateMembers(teamId, [], [osmId])
 }
 
@@ -237,7 +241,7 @@ async function removeMember (teamId, osmId) {
 async function assignModerator (teamId, osmId) {
   const conn = await db()
   if (!await isMember(teamId, osmId)) {
-    throw new Error('cannot assign osmId to be moderator because they are not a team member yet.')
+    throw new Error('cannot assign osmId to be moderator because they are not a team member yet')
   }
   return unpack(conn('moderator').insert({ team_id: teamId, osm_id: osmId }))
 }
@@ -261,7 +265,7 @@ async function removeModerator (teamId, osmId) {
   }
   const modCount = parseInt((await unpack(conn(table).where({ team_id: teamId }).count())).count)
   if (modCount === 1) {
-    throw new Error('cannot remove osmId because there is only one moderator remaining')
+    throw new Error('cannot remove osmId because there must be at least one moderator')
   }
   await moderatorRecord.del()
 }

--- a/app/lib/team.js
+++ b/app/lib/team.js
@@ -256,14 +256,14 @@ async function removeModerator (teamId, osmId) {
   const table = 'moderator'
   const conn = await db()
   const moderatorRecord = conn(table).where({ team_id: teamId, osm_id: osmId })
-  const isModerator = parseInt((await unpack(moderatorRecord.count())).count) > 0
+  const isModerator = (await moderatorRecord).length > 0
   /* the isModerator() function could have been used here ^, but since we are
    * going to del() the record at the end of this function, calling isModerator()
    * would add a db query. */
   if (!isModerator) {
     throw new Error('cannot remove osmId because osmId is not a moderator')
   }
-  const modCount = parseInt((await unpack(conn(table).where({ team_id: teamId }).count())).count)
+  const modCount = (await conn(table).where({ team_id: teamId })).length
   if (modCount === 1) {
     throw new Error('cannot remove osmId because there must be at least one moderator')
   }
@@ -280,8 +280,8 @@ async function isModerator (teamId, osmId) {
   if (!teamId) throw new Error('team id is required as first argument')
   if (!osmId) throw new Error('osm id is required as second argument')
   const conn = await db()
-  const [{ count }] = await conn('moderator').where({ team_id: teamId, osm_id: osmId }).count()
-  return parseInt(count) > 0
+  const result = await conn('moderator').where({ team_id: teamId, osm_id: osmId })
+  return result.length > 0
 }
 
 /**
@@ -294,8 +294,8 @@ async function isMember (teamId, osmId) {
   if (!teamId) throw new Error('team id is required as first argument')
   if (!osmId) throw new Error('osm id is required as second argument')
   const conn = await db()
-  const [{ count }] = await conn('member').where({ team_id: teamId, osm_id: osmId }).count()
-  return parseInt(count) > 0
+  const result = await conn('member').where({ team_id: teamId, osm_id: osmId })
+  return result.length > 0
 }
 
 /**

--- a/app/manage/index.js
+++ b/app/manage/index.js
@@ -7,15 +7,17 @@ const { can } = require('./permissions')
 const sessionMiddleware = require('./sessions')
 const logger = require('../lib/logger')
 const {
-  listTeams,
-  createTeam,
-  getTeam,
-  updateTeam,
-  destroyTeam,
   addMember,
+  assignModerator,
+  createTeam,
+  destroyTeam,
+  getTeam,
+  joinTeam,
+  listTeams,
   removeMember,
+  removeModerator,
   updateMembers,
-  joinTeam
+  updateTeam
 } = require('./teams')
 
 /**
@@ -55,7 +57,7 @@ function manageRouter (nextApp) {
   router.delete('/api/clients/:id', can('client:delete'), deleteClient)
 
   /**
-   * List / Create / Delete teams
+   * List, Create, Read, Update, Delete operations on teams.
    */
   router.get('/api/teams', listTeams)
   router.post('/api/teams', can('team:create'), createTeam)
@@ -66,6 +68,8 @@ function manageRouter (nextApp) {
   router.put('/api/teams/remove/:id/:osmId', can('team:update'), removeMember)
   router.patch('/api/teams/:id/members', can('team:update'), updateMembers)
   router.put('/api/teams/:id/join', can('team:join'), joinTeam)
+  router.patch('/api/teams/:id/assignModerator/:osmId', can('team:update'), assignModerator)
+  router.patch('/api/teams/:id/removeModerator/:osmId', can('team:update'), removeModerator)
 
   /**
    * Page renders

--- a/app/manage/index.js
+++ b/app/manage/index.js
@@ -68,8 +68,8 @@ function manageRouter (nextApp) {
   router.put('/api/teams/remove/:id/:osmId', can('team:update'), removeMember)
   router.patch('/api/teams/:id/members', can('team:update'), updateMembers)
   router.put('/api/teams/:id/join', can('team:join'), joinTeam)
-  router.patch('/api/teams/:id/assignModerator/:osmId', can('team:update'), assignModerator)
-  router.patch('/api/teams/:id/removeModerator/:osmId', can('team:update'), removeModerator)
+  router.put('/api/teams/:id/assignModerator/:osmId', can('team:update'), assignModerator)
+  router.put('/api/teams/:id/removeModerator/:osmId', can('team:update'), removeModerator)
 
   /**
    * Page renders

--- a/app/manage/teams.js
+++ b/app/manage/teams.js
@@ -101,7 +101,7 @@ async function assignModerator (req, reply) {
     reply.send(data)
   } catch (err) {
     console.log(err)
-    return reply.boom.badRequest()
+    return reply.boom.badRequest(err)
   }
 }
 
@@ -121,7 +121,7 @@ async function removeModerator (req, reply) {
     reply.send(data)
   } catch (err) {
     console.log(err)
-    return reply.boom.badRequest()
+    return reply.boom.badRequest(err)
   }
 }
 

--- a/app/manage/teams.js
+++ b/app/manage/teams.js
@@ -19,7 +19,7 @@ async function listTeams (req, reply) {
     reply.send(data)
   } catch (err) {
     console.log(err)
-    return reply.boom.badRequest()
+    return reply.boom.badRequest(err.message)
   }
 }
 
@@ -43,7 +43,7 @@ async function getTeam (req, reply) {
     return reply.send(Object.assign({}, teamData, { members, moderators }))
   } catch (err) {
     console.log(err)
-    return reply.boom.badRequest()
+    return reply.boom.badRequest(err.message)
   }
 }
 
@@ -81,7 +81,7 @@ async function updateTeam (req, reply) {
     reply.send(data)
   } catch (err) {
     console.log(err)
-    return reply.boom.badRequest()
+    return reply.boom.badRequest(err.message)
   }
 }
 
@@ -101,7 +101,7 @@ async function assignModerator (req, reply) {
     reply.send(data)
   } catch (err) {
     console.log(err)
-    return reply.boom.badRequest(err)
+    return reply.boom.badRequest(err.message)
   }
 }
 
@@ -121,7 +121,7 @@ async function removeModerator (req, reply) {
     reply.send(data)
   } catch (err) {
     console.log(err)
-    return reply.boom.badRequest(err)
+    return reply.boom.badRequest(err.message)
   }
 }
 
@@ -137,7 +137,7 @@ async function destroyTeam (req, reply) {
     reply.sendStatus(200)
   } catch (err) {
     console.log(err)
-    return reply.boom.badRequest()
+    return reply.boom.badRequest(err.message)
   }
 }
 
@@ -157,7 +157,7 @@ async function addMember (req, reply) {
     return reply.sendStatus(200)
   } catch (err) {
     console.log(err)
-    return reply.boom.badRequest()
+    return reply.boom.badRequest(err.message)
   }
 }
 
@@ -178,7 +178,7 @@ async function updateMembers (req, reply) {
     return reply.sendStatus(200)
   } catch (err) {
     console.log(err)
-    return reply.boom.badRequest()
+    return reply.boom.badRequest(err.message)
   }
 }
 
@@ -198,7 +198,7 @@ async function removeMember (req, reply) {
     return reply.sendStatus(200)
   } catch (err) {
     console.log(err)
-    return reply.boom.badRequest()
+    return reply.boom.badRequest(err.message)
   }
 }
 
@@ -219,7 +219,7 @@ async function joinTeam (req, reply) {
     return reply.sendStatus(200)
   } catch (err) {
     console.log(err)
-    return reply.boom.badRequest()
+    return reply.boom.badRequest(err.message)
   }
 }
 

--- a/app/manage/teams.js
+++ b/app/manage/teams.js
@@ -85,6 +85,46 @@ async function updateTeam (req, reply) {
   }
 }
 
+async function assignModerator (req, reply) {
+  const { id: teamId, osmId } = req.params
+
+  if (!teamId) {
+    return reply.boom.badRequest('team id is required')
+  }
+
+  if (!osmId) {
+    return reply.boom.badRequest('osm id of member to promote to moderator is required')
+  }
+
+  try {
+    const data = await team.assignModerator(teamId, osmId)
+    reply.send(data)
+  } catch (err) {
+    console.log(err)
+    return reply.boom.badRequest()
+  }
+}
+
+async function removeModerator (req, reply) {
+  const { id: teamId, osmId } = req.params
+
+  if (!teamId) {
+    return reply.boom.badRequest('team id is required')
+  }
+
+  if (!osmId) {
+    return reply.boom.badRequest('osm id of member to demote from moderator is required')
+  }
+
+  try {
+    const data = await team.removeModerator(teamId, osmId)
+    reply.send(data)
+  } catch (err) {
+    console.log(err)
+    return reply.boom.badRequest()
+  }
+}
+
 async function destroyTeam (req, reply) {
   const { id } = req.params
 
@@ -184,13 +224,15 @@ async function joinTeam (req, reply) {
 }
 
 module.exports = {
-  listTeams,
-  getTeam,
-  createTeam,
-  updateTeam,
-  destroyTeam,
   addMember,
-  updateMembers,
+  assignModerator,
+  createTeam,
+  destroyTeam,
+  getTeam,
+  joinTeam,
+  listTeams,
   removeMember,
-  joinTeam
+  removeModerator,
+  updateMembers,
+  updateTeam
 }

--- a/app/tests/api/team-api.test.js
+++ b/app/tests/api/team-api.test.js
@@ -195,3 +195,9 @@ test('get list of teams by bbox', async t => {
 
   t.true(teams.body.length > 0)
 })
+
+test('assign moderator to team', async t => {
+})
+
+test('remove moderator from team', async t => {
+})

--- a/app/tests/api/team-model.test.js
+++ b/app/tests/api/team-model.test.js
@@ -104,18 +104,16 @@ test('add team member', async t => {
 })
 
 test('remove team member', async t => {
-  const created = await team.create({ name: 'boundary team 4' }, 1)
-  await team.addMember(created.id, 1)
+  const moderatorId = 1
+  // add a different osm id as member
+  const memberId = 2
+  const created = await team.create({ name: 'boundary team 4' }, moderatorId)
+  await team.addMember(created.id, memberId)
   const members = await team.getMembers(created.id)
-  t.true(members.length === 1)
-
-  await team.removeMember(created.id, 1)
+  t.true(members.length === 2)
+  await team.removeMember(created.id, memberId)
   const newMembers = await team.getMembers(created.id)
-  t.true(newMembers.length === 0)
-})
-
-test('remove team member also removes moderator', async t => {
-  // could this be done with sql cascade on delete?
+  t.true(newMembers.length === 1)
 })
 
 test('update team members', async t => {
@@ -154,13 +152,51 @@ test('list teams with bounding box', async (t) => {
 })
 
 test('assign moderator to team', async t => {
+  const created = await team.create({ name: 'map team ♾' }, 1)
+  const { id: teamId } = created
+  await team.addMember(teamId, 2)
+  await team.assignModerator(teamId, 2)
+  const isMod = await team.isModerator(teamId, 2)
+  t.true(isMod)
 })
 
 test('remove moderator from team', async t => {
+  const created = await team.create({ name: 'map team ♾+1' }, 1)
+  const { id: teamId } = created
+  await team.addMember(teamId, 2)
+  await team.assignModerator(teamId, 2)
+  await team.removeModerator(teamId, 2)
+  const isMod = await team.isModerator(teamId, 2)
+  t.false(isMod)
 })
 
 test('moderator cannot be removed if it leaves team moderator-less', async t => {
+  const created = await team.create({ name: 'map team ♾+2' }, 1)
+  const { id: teamId } = created
+  try {
+    await team.removeModerator(teamId, 1)
+  } catch (e) {
+    t.is(e.message, 'cannot remove osmId because there must be at least one moderator')
+  }
 })
 
 test('moderator cannot be assigned if osm id is not already a member', async t => {
+  const created = await team.create({ name: 'map team ♾+3' }, 1)
+  const { id: teamId } = created
+  try {
+    await team.assignModerator(teamId, 2)
+  } catch (e) {
+    t.is(e.message, 'cannot assign osmId to be moderator because they are not a team member yet')
+  }
+})
+
+test('remove team member also removes moderator', async t => {
+  const osmId = 2
+  const created = await team.create({ name: 'map team ♾+4' }, 1)
+  const { id: teamId } = created
+  await team.addMember(teamId, osmId)
+  await team.assignModerator(teamId, osmId)
+  await team.removeMember(teamId, osmId)
+  const isMod = await team.isModerator(teamId, osmId)
+  t.false(isMod)
 })

--- a/app/tests/api/team-model.test.js
+++ b/app/tests/api/team-model.test.js
@@ -114,6 +114,10 @@ test('remove team member', async t => {
   t.true(newMembers.length === 0)
 })
 
+test('remove team member also removes moderator', async t => {
+  // could this be done with sql cascade on delete?
+})
+
 test('update team members', async t => {
   const created = await team.create({ name: 'boundary team 5' }, 1)
   await team.addMember(created.id, 1)
@@ -147,4 +151,16 @@ test('list teams with bounding box', async (t) => {
 
   t.true(Array.isArray(list1) && list1.length === 1)
   t.true(Array.isArray(list2) && list2.length === 0)
+})
+
+test('assign moderator to team', async t => {
+})
+
+test('remove moderator from team', async t => {
+})
+
+test('moderator cannot be removed if it leaves team moderator-less', async t => {
+})
+
+test('moderator cannot be assigned if osm id is not already a member', async t => {
 })

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   hydra:
-    image: oryd/hydra:v1.0.0-rc.11
+    image: oryd/hydra:v1
     ports:
     - 4444:4444
     - 4445:4445

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   hydra:
-    image: oryd/hydra:v1.0.0-rc.11
+    image: oryd/hydra:v1
     ports:
     - 4444:4444
     - 4445:4445

--- a/docs/api.md
+++ b/docs/api.md
@@ -188,3 +188,47 @@ add and remove team members from a team
 | ---- | ----------- |
 | 200 | team members are added/removed |
 | 400 | error updating team members |
+
+### /teams/{id}/assignModerator/{osmId}
+
+#### PUT
+##### Summary:
+
+Assign/Promote a member to be moderator of a team. More than one moderator may exist concurrently. Moderators are listed in the TeamModeratorList schema.
+
+
+##### Parameters
+
+| Name | Located in | Description | Required | Schema |
+| ---- | ---------- | ----------- | -------- | ---- |
+|  |  |  | No | [TeamId](#teamid) |
+|  |  |  | No | [OsmId](#osmid) |
+
+##### Responses
+
+| Code | Description |
+| ---- | ----------- |
+| 200 | member was promoted to moderator |
+| 400 | error updating moderator relation |
+
+### /teams/{id}/removeModerator/{osmId}
+
+#### PUT
+##### Summary:
+
+Remove/Demote a moderator of a team. At least one moderator must exist for a team. Moderators are listed in the TeamModeratorList schema.
+
+
+##### Parameters
+
+| Name | Located in | Description | Required | Schema |
+| ---- | ---------- | ----------- | -------- | ---- |
+|  |  |  | No | [TeamId](#teamid) |
+|  |  |  | No | [OsmId](#osmid) |
+
+##### Responses
+
+| Code | Description |
+| ---- | ----------- |
+| 200 | member was demoted from moderator |
+| 400 | error updating moderator relation |

--- a/docs/api.yml
+++ b/docs/api.yml
@@ -415,3 +415,42 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ResponseError'
+  /teams/{id}/assignModerator/{osmId}:
+    parameters:
+      - $ref: '#/components/parameters/TeamId'
+      - $ref: '#/components/parameters/OsmId'
+    put:
+      summary: >
+        Assign/Promote a member to be moderator of a team. More than one
+        moderator may exist concurrently. Moderators are listed in the
+        TeamModeratorList schema.
+      tags:
+        - teams      
+      responses:
+        '200':
+          description: member was promoted to moderator
+        '400':
+          description: error updating moderator relation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+  /teams/{id}/removeModerator/{osmId}:
+    parameters:
+      - $ref: '#/components/parameters/TeamId'
+      - $ref: '#/components/parameters/OsmId'
+    put:
+      summary: >
+        Remove/Demote a moderator of a team. At least one moderator must exist
+        for a team. Moderators are listed in the TeamModeratorList schema.
+      tags:
+        - teams      
+      responses:
+        '200':
+          description: member was demoted from moderator
+        '400':
+          description: error updating moderator relation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "express-session": "^1.15.6",
     "formik": "^1.5.8",
     "jsonwebtoken": "^8.5.0",
-    "knex": "^0.16.3",
+    "knex": "^0.20.8",
     "knex-postgis": "^0.8.1",
     "leaflet": "^1.5.1",
     "leaflet-control-geocoder": "^1.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -820,14 +820,6 @@
     "@babel/helper-regex" "^7.4.4"
     regexpu-core "^4.5.4"
 
-"@babel/polyfill@^7.4.3":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.4.4.tgz#78801cf3dbe657844eeabf31c1cae3828051e893"
-  integrity sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==
-  dependencies:
-    core-js "^2.6.5"
-    regenerator-runtime "^0.13.2"
-
 "@babel/preset-env@7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.1.0.tgz#e67ea5b0441cfeab1d6f41e9b5c79798800e8d11"
@@ -1067,11 +1059,6 @@
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
-
-"@types/bluebird@^3.5.26":
-  version "3.5.27"
-  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.27.tgz#61eb4d75dc6bfbce51cf49ee9bbebe941b2cb5d0"
-  integrity sha512-6BmYWSBea18+tSjjSC3QIyV93ZKAeNWGM7R6aYt1ryTZXrlHF+QLV0G2yV0viEGVyRkyQsWfMoJ0k/YghBX5sQ==
 
 "@types/events@*":
   version "3.0.0"
@@ -1926,10 +1913,15 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
-bluebird@^3.5.0, bluebird@^3.5.3, bluebird@^3.5.4, bluebird@^3.5.5:
+bluebird@^3.5.0, bluebird@^3.5.3, bluebird@^3.5.5:
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
   integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
+
+bluebird@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
+  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
@@ -2547,10 +2539,10 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-colorette@1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.0.7.tgz#7adf43c445ee63a541b4a4aef7d13f03df1e0cc0"
-  integrity sha512-KeK4klsvAgdODAjFPm6QLzvStizJqlxMBtVo4KQMCgk5tt/tf9rAzxmxLHNRynJg3tJjkKGKbHx3j4HLox27Lw==
+colorette@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.1.0.tgz#1f943e5a357fac10b4e0f5aaef3b14cdc1af6ec7"
+  integrity sha512-6S062WDQUXi6hOfkO/sBPVwE5ASXY4G2+b4atvhJfSsuUUhIaUKlkjLe9692Ipyt5/a+IPF5aVTu3V5gvXq5cg==
 
 colors@1.1.2:
   version "1.1.2"
@@ -2585,6 +2577,11 @@ commander@^2.11.0, commander@^2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
+
+commander@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.0.tgz#545983a0603fe425bc672d66c9e3c89c42121a83"
+  integrity sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==
 
 commander@~2.17.1:
   version "2.17.1"
@@ -2792,7 +2789,7 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
-core-js@^2.0.0, core-js@^2.4.0, core-js@^2.5.7, core-js@^2.6.5:
+core-js@^2.0.0, core-js@^2.4.0, core-js@^2.5.7:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
@@ -3710,7 +3707,7 @@ eslint@~5.9.0:
     table "^5.0.2"
     text-table "^0.2.0"
 
-esm@^3.2.20:
+esm@^3.2.20, esm@^3.2.25:
   version "3.2.25"
   resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
   integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
@@ -4345,10 +4342,10 @@ get-value@^2.0.3, get-value@^2.0.6:
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
-getopts@2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/getopts/-/getopts-2.2.3.tgz#11d229775e2ec2067ed8be6fcc39d9b4bf39cf7d"
-  integrity sha512-viEcb8TpgeG05+Nqo5EzZ8QR0hxdyrYDp6ZSTZqe2M/h53Bk036NmqG38Vhf5RGirC/Of9Xql+v66B2gp256SQ==
+getopts@2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/getopts/-/getopts-2.2.5.tgz#67a0fe471cacb9c687d817cab6450b96dde8313b"
+  integrity sha512-9jb7AW5p3in+IiJWhQiZmmwkpLaR/ccTWdWQCtZM66HJcHHLegowh4q4tSD7gouUyeNvFWRavfK9GXosQHDpFA==
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -4756,7 +4753,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -4833,10 +4830,10 @@ internal-ip@^3.0.1:
     default-gateway "^2.6.0"
     ipaddr.js "^1.5.2"
 
-interpret@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
-  integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
+interpret@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.0.0.tgz#b783ffac0b8371503e9ab39561df223286aa5433"
+  integrity sha512-e0/LknJ8wpMMhTiWcjivB+ESwIuvHnBSlBbmP/pSb8CQJldoj1p2qv7xGZ/+BtbTziYRFSz8OsvdbiX45LtYQA==
 
 invariant@^2.2.2:
   version "2.2.4"
@@ -5464,28 +5461,27 @@ knex-postgis@^0.8.1:
   dependencies:
     "@mapbox/geojsonhint" "^3.0.0"
 
-knex@^0.16.3:
-  version "0.16.5"
-  resolved "https://registry.yarnpkg.com/knex/-/knex-0.16.5.tgz#8ba3806289a5d543dd42ed21420a31c578476993"
-  integrity sha512-1RVxMU8zGOBqgmXlAvs8vohg9MD14iiRZZPe0IeQXd554n4xxPmoMkbH4hlFeqfM6eOdFE3AVqVSncL3YuocqA==
+knex@^0.20.8:
+  version "0.20.8"
+  resolved "https://registry.yarnpkg.com/knex/-/knex-0.20.8.tgz#b41c72773185e1032f4a77074198413521827860"
+  integrity sha512-fLiSg5PIBisORs0M+UGjg2s1P/E1BrYvb/NkSVk6Y90HJujkqLufSC6ag+hDgXqW73mFAF283M6+q3/NW0TrHw==
   dependencies:
-    "@babel/polyfill" "^7.4.3"
-    "@types/bluebird" "^3.5.26"
-    bluebird "^3.5.4"
-    colorette "1.0.7"
-    commander "^2.20.0"
+    bluebird "^3.7.2"
+    colorette "1.1.0"
+    commander "^4.1.0"
     debug "4.1.1"
-    getopts "2.2.3"
-    inherits "~2.0.3"
-    interpret "^1.2.0"
+    esm "^3.2.25"
+    getopts "2.2.5"
+    inherits "~2.0.4"
+    interpret "^2.0.0"
     liftoff "3.1.0"
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     mkdirp "^0.5.1"
-    pg-connection-string "2.0.0"
-    tarn "^1.1.5"
-    tildify "1.2.0"
-    uuid "^3.3.2"
-    v8flags "^3.1.2"
+    pg-connection-string "2.1.0"
+    tarn "^2.0.0"
+    tildify "2.0.0"
+    uuid "^3.3.3"
+    v8flags "^3.1.3"
 
 labeled-stream-splicer@^2.0.0:
   version "2.0.2"
@@ -5714,7 +5710,7 @@ lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
 
-lodash@^4.17.13:
+lodash@^4.17.13, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -6981,10 +6977,10 @@ pg-connection-string@0.1.3:
   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-0.1.3.tgz#da1847b20940e42ee1492beaf65d49d91b245df7"
   integrity sha1-2hhHsglA5C7hSSvq9l1J2RskXfc=
 
-pg-connection-string@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.0.0.tgz#3eefe5997e06d94821e4d502e42b6a1c73f8df82"
-  integrity sha1-Pu/lmX4G2Ugh5NUC5CtqHHP434I=
+pg-connection-string@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.1.0.tgz#e07258f280476540b24818ebb5dca29e101ca502"
+  integrity sha512-bhlV7Eq09JrRIvo1eKngpwuqKtJnNhZdpdOlvrPrA4dxqXPjxSrbNrfnIDmTpwMyRszrcV4kU5ZA4mMsQUrjdg==
 
 pg-int8@1.0.1:
   version "1.0.1"
@@ -8756,10 +8752,10 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
 
-tarn@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/tarn/-/tarn-1.1.5.tgz#7be88622e951738b9fa3fb77477309242cdddc2d"
-  integrity sha512-PMtJ3HCLAZeedWjJPgGnCvcphbCOMbtZpjKgLq3qM5Qq9aQud+XHrL0WlrlgnTyS8U+jrjGbEXprFcQrxPy52g==
+tarn@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tarn/-/tarn-2.0.0.tgz#c68499f69881f99ae955b4317ca7d212d942fdee"
+  integrity sha512-7rNMCZd3s9bhQh47ksAQd92ADFcJUjjbyOvyFjNLwTPpGieFHMC84S+LOzw0fx1uh6hnDz/19r8CPMnIjJlMMA==
 
 term-color@^1.0.1:
   version "1.0.1"
@@ -8836,12 +8832,10 @@ through@2, "through@>=2.2.7 <3", through@^2.3.6:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
-tildify@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/tildify/-/tildify-1.2.0.tgz#dcec03f55dca9b7aa3e5b04f21817eb56e63588a"
-  integrity sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=
-  dependencies:
-    os-homedir "^1.0.0"
+tildify@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tildify/-/tildify-2.0.0.tgz#f205f3674d677ce698b7067a99e949ce03b4754a"
+  integrity sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw==
 
 time-zone@^1.0.0:
   version "1.0.0"
@@ -9319,7 +9313,12 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-v8flags@^3.1.2:
+uuid@^3.3.3:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+v8flags@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.1.3.tgz#fc9dc23521ca20c5433f81cc4eb9b3033bb105d8"
   integrity sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==


### PR DESCRIPTION
Builds upon existing database schema and api implementation to add 2 new api endpoints:

```
/api/teams/:id/assignModerator/:osmId
/api/teams/:id/removeModerator/:osmId
```

- [x] Add unique constraint on moderator table.
- [x] Add unique constraint on member table.
- [x] Add api endpoints
- [x]  Multiple moderators may be assigned to a team.
- [x] Only moderators are allowed to invoke these endpoints.
- [x] `removeModerator` fails if it would leave the team moderator-less (minimum 1 mod is required)
- [x] `assignModerator` fails if the osmId is not already a member of the team (instead of adding them as a side effect, instead of having moderators who are not also members)
- [x] Unit/Integration tests
- [x] Swagger api docs

Closes #127 