### PR TITLE
New API route for "my teams" and "my moderated teams"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tmp
 *.db
 # ignore node_modules symlink
 node_modules.nosync
+.idea

--- a/app/lib/team.js
+++ b/app/lib/team.js
@@ -110,6 +110,21 @@ async function list (options) {
 }
 
 /**
+ * List all the teams which osm id is a moderator of.
+ *
+ * @param {*} osmId osm user id to filter by
+ * @returns {Promise[Array]}
+ */
+async function listModeratedBy (osmId) {
+  const conn = await db()
+  const st = knexPostgis(conn)
+  const query = conn('team')
+    .select('*', st.asGeoJSON('location'))
+    .whereIn('id', subQuery => subQuery.select('team_id').from('moderator').where('osm_id', osmId))
+  return query
+}
+
+/**
 * Create a team
 * Teams have to have moderators, so we give an osm id
 * as the second param
@@ -315,6 +330,7 @@ async function isPublic (teamId) {
 module.exports = {
   get,
   list,
+  listModeratedBy,
   create,
   update,
   destroy,

--- a/app/manage/index.js
+++ b/app/manage/index.js
@@ -3,7 +3,7 @@ const expressPino = require('express-pino-logger')
 
 const { getClients, createClient, deleteClient } = require('./client')
 const { login, loginAccept, logout } = require('./login')
-const { authenticate, can } = require('./permissions')
+const { can } = require('./permissions')
 const sessionMiddleware = require('./sessions')
 const logger = require('../lib/logger')
 const {
@@ -61,7 +61,7 @@ function manageRouter (nextApp) {
    * List, Create, Read, Update, Delete operations on teams.
    */
   router.get('/api/teams', listTeams)
-  router.get('/api/my/teams', authenticate, listMyTeams)
+  router.get('/api/my/teams', can('public:authenticated'), listMyTeams)
   router.post('/api/teams', can('team:create'), createTeam)
   router.get('/api/teams/:id', can('team:view'), getTeam)
   router.put('/api/teams/:id', can('team:update'), updateTeam)

--- a/app/manage/index.js
+++ b/app/manage/index.js
@@ -3,7 +3,7 @@ const expressPino = require('express-pino-logger')
 
 const { getClients, createClient, deleteClient } = require('./client')
 const { login, loginAccept, logout } = require('./login')
-const { can } = require('./permissions')
+const { authenticate, can } = require('./permissions')
 const sessionMiddleware = require('./sessions')
 const logger = require('../lib/logger')
 const {
@@ -14,6 +14,7 @@ const {
   getTeam,
   joinTeam,
   listTeams,
+  listMyTeams,
   removeMember,
   removeModerator,
   updateMembers,
@@ -60,6 +61,7 @@ function manageRouter (nextApp) {
    * List, Create, Read, Update, Delete operations on teams.
    */
   router.get('/api/teams', listTeams)
+  router.get('/api/my/teams', authenticate, listMyTeams)
   router.post('/api/teams', can('team:create'), createTeam)
   router.get('/api/teams/:id', can('team:view'), getTeam)
   router.put('/api/teams/:id', can('team:update'), updateTeam)

--- a/app/manage/permissions/index.js
+++ b/app/manage/permissions/index.js
@@ -3,7 +3,7 @@ const hydra = require('../../lib/hydra')
 const { mergeAll } = require('ramda')
 
 const metaPermissions = {
-  'public': () => true
+  'public:authenticated': () => true
 }
 
 const teamPermissions = {

--- a/app/manage/teams.js
+++ b/app/manage/teams.js
@@ -23,6 +23,11 @@ async function listTeams (req, reply) {
   }
 }
 
+async function listMyTeams (req, reply) {
+  const { user_id: osmId } = reply.locals
+  reply.send({ osmId })
+}
+
 async function getTeam (req, reply) {
   const { id } = req.params
 
@@ -50,6 +55,7 @@ async function getTeam (req, reply) {
 async function createTeam (req, reply) {
   const { body } = req
   const { user_id } = reply.locals
+  console.log(user_id)
 
   if (body.editing_policy && !isUrl.test(body.editing_policy)) {
     return reply.boom.badRequest('editing_policy must be a valid url')
@@ -231,6 +237,7 @@ module.exports = {
   getTeam,
   joinTeam,
   listTeams,
+  listMyTeams,
   removeMember,
   removeModerator,
   updateMembers,

--- a/app/manage/teams.js
+++ b/app/manage/teams.js
@@ -25,7 +25,18 @@ async function listTeams (req, reply) {
 
 async function listMyTeams (req, reply) {
   const { user_id: osmId } = reply.locals
-  reply.send({ osmId })
+  try {
+    const memberOfTeams = await team.list({ osmId })
+    const moderatorOfTeams = await team.listModeratedBy(osmId)
+    const result = {
+      osmId,
+      member: memberOfTeams,
+      moderator: moderatorOfTeams
+    }
+    reply.send(result)
+  } catch (err) {
+    return reply.boom.badRequest(err.message)
+  }
 }
 
 async function getTeam (req, reply) {
@@ -55,8 +66,6 @@ async function getTeam (req, reply) {
 async function createTeam (req, reply) {
   const { body } = req
   const { user_id } = reply.locals
-  console.log(user_id)
-
   if (body.editing_policy && !isUrl.test(body.editing_policy)) {
     return reply.boom.badRequest('editing_policy must be a valid url')
   }

--- a/app/tests/api/team-api.test.js
+++ b/app/tests/api/team-api.test.js
@@ -244,7 +244,11 @@ test('remove moderator from team', async t => {
 })
 
 test('get my teams list', async t => {
-  // create two teams (osmId = 1)
+  // get previous teams list for checking relative counts within this test.
+  let response = await agent.get(`/api/my/teams`)
+    .expect(200)
+  const { member: prevMember, moderator: prevModerator } = response.body
+  // create two more teams (osmId = 1)
   await agent.post('/api/teams')
     .send({ name: 'map team ♾+2' })
     .expect(200)
@@ -260,14 +264,13 @@ test('get my teams list', async t => {
   // remove osmId 1 from moderator
   await agent.put(`/api/teams/${teamId}/removeModerator/1`)
     .expect(200)
-  // check myTeams listing
-  const response = await agent.get(`/api/my/teams`)
+  // check that osmId 1 is now +1 moderator and +2 member
+  response = await agent.get(`/api/my/teams`)
     .expect(200)
   const { osmId, member, moderator } = response.body
   t.is(osmId, 1)
-  t.assert(moderator.length > 0)
-  t.assert(member.length > 0)
-  t.not(member.length, moderator.length)
+  t.is(moderator.length, prevModerator.length + 1)
+  t.is(member.length, prevMember.length + 2)
   member.forEach(item => {
     t.truthy(item.name)
     t.truthy(item.id)

--- a/app/tests/api/team-api.test.js
+++ b/app/tests/api/team-api.test.js
@@ -263,7 +263,6 @@ test('get my teams list', async t => {
   // check myTeams listing
   const myTeams = await agent.get(`/api/my/teams`)  // eslint-disable-line
     .expect(200)
-    .expect(400)
   t.truthy(myTeams)
   const { osmId, member, moderator } = myTeams
   t.is(osmId, 1)

--- a/app/tests/api/team-api.test.js
+++ b/app/tests/api/team-api.test.js
@@ -20,15 +20,16 @@ test.before(async () => {
   await conn('users').insert({ id: 3 })
   await conn('users').insert({ id: 4 })
 
-  // Ensure authenticate middleware always goes through
-  sinon.stub(permissions, 'can').callsFake(
-    function () {
-      return function (req, res, next) {
-        res.locals.user_id = 1
-        return next()
-      }
+  // Ensure authenticate middleware always goes through with user_id 1
+  const middleware = function () {
+    return function (req, res, next) {
+      res.locals.user_id = 1
+      return next()
     }
-  )
+  }
+  sinon.stub(permissions, 'can').callsFake(middleware)
+  sinon.stub(permissions, 'authenticate').callsFake(middleware)
+  sinon.stub(permissions, 'check').callsFake(middleware)
 
   // Ensure that resolveMemberNames never calls osm
   sinon.stub(team, 'resolveMemberNames').callsFake((ids) => {
@@ -240,4 +241,40 @@ test('remove moderator from team', async t => {
   t.is(name, teamName)
   const matchOsmIdAssigned = data => data.osm_id === osmId
   t.false(any(matchOsmIdAssigned, moderators))
+})
+
+test('get my teams list', async t => {
+  // create two teams (osmId = 1)
+  await agent.post('/api/teams')
+    .send({ name: 'map team ♾+2' })
+    .expect(200)
+  const team = await agent.post('/api/teams')
+    .send({ name: 'map team ♾+3' })
+    .expect(200)
+  const { id: teamId } = team.body
+  // add osmId 2 to one team, and make them moderator
+  await agent.put(`/api/teams/add/${teamId}/2`)
+    .expect(200)
+  await agent.put(`/api/teams/${teamId}/assignModerator/2`)
+    .expect(200)
+  // remove osmId 1 from moderator
+  await agent.put(`/api/teams/${teamId}/removeModerator/1`)
+    .expect(200)
+  // check myTeams listing
+  const myTeams = await agent.get(`/api/my/teams`)  // eslint-disable-line
+    .expect(200)
+    .expect(400)
+  t.truthy(myTeams)
+  const { osmId, member, moderator } = myTeams
+  t.is(osmId, 1)
+  t.is(member.length, 2)
+  t.is(moderator.length, 1)
+  member.forEach(item => {
+    t.truthy(item.name)
+    t.truthy(item.id)
+  })
+  moderator.forEach(item => {
+    t.truthy(item.name)
+    t.truthy(item.id)
+  })
 })

--- a/app/tests/api/team-api.test.js
+++ b/app/tests/api/team-api.test.js
@@ -261,13 +261,13 @@ test('get my teams list', async t => {
   await agent.put(`/api/teams/${teamId}/removeModerator/1`)
     .expect(200)
   // check myTeams listing
-  const myTeams = await agent.get(`/api/my/teams`)  // eslint-disable-line
+  const response = await agent.get(`/api/my/teams`)
     .expect(200)
-  t.truthy(myTeams)
-  const { osmId, member, moderator } = myTeams
+  const { osmId, member, moderator } = response.body
   t.is(osmId, 1)
-  t.is(member.length, 2)
-  t.is(moderator.length, 1)
+  t.assert(moderator.length > 0)
+  t.assert(member.length > 0)
+  t.not(member.length, moderator.length)
   member.forEach(item => {
     t.truthy(item.name)
     t.truthy(item.id)


### PR DESCRIPTION
- Add new route /api/my/teams which returns teams the authenticated user is a member of, and teams they moderate (if any).
- Add unit test.
- Add `team.listModeratedBy`.
- Rename permission `public` to `public-authenticated`

I tested this by using a bearer token from the cli, for example:

```bash
 curl -H "Authorization: Bearer $OSM_TEAMS_BEARER_TOKEN" http://localhost:8989/api/my/teams | jq .
```

Closes #145 