### PR TITLE
Simplify login

### DIFF
--- a/components/sidebar.js
+++ b/components/sidebar.js
@@ -2,7 +2,6 @@ import React, { Component, Fragment } from 'react'
 import join from 'url-join'
 import getConfig from 'next/config'
 import Router, { withRouter } from 'next/router'
-import Button from '../components/button'
 import theme from '../styles/theme'
 import Link from '../components/Link'
 

--- a/components/sidebar.js
+++ b/components/sidebar.js
@@ -2,6 +2,7 @@ import React, { Component, Fragment } from 'react'
 import join from 'url-join'
 import getConfig from 'next/config'
 import Router, { withRouter } from 'next/router'
+import Button from '../components/button'
 import theme from '../styles/theme'
 import Link from '../components/Link'
 
@@ -73,7 +74,7 @@ class Sidebar extends Component {
                 Router.push('/logout')
               }
               }>Log Out</a>
-              : <NavLink href='/login'><a className='global-menu__link login'>Sign in</a></NavLink>
+              : <a className='global-menu__link login danger' href={join(URL, '/login')}>Sign in </a>
           }
         </nav>
         <style jsx global>

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,7 +1,5 @@
-import Button from '../components/button'
 import React, { Component } from 'react'
-import getConfig from 'next/config'
-const { publicRuntimeConfig } = getConfig()
+import Router from 'next/router'
 
 class Login extends Component {
   static async getInitialProps ({ query }) {
@@ -12,16 +10,12 @@ class Login extends Component {
     }
   }
 
+  componentDidMount () {
+    Router.push(`/oauth/openstreetmap?login_challenge=${this.props.challenge}`)
+  }
+
   render () {
-    const OSM_NAME = publicRuntimeConfig.OSM_NAME
-    return (
-      <section className='inner page'>
-        <h1>Login Provider</h1>
-        <p>Teams uses {OSM_NAME} as your login, connect your {OSM_NAME} account!</p>
-        <br />
-        <Button href={`/oauth/openstreetmap?login_challenge=${this.props.challenge}`}>Login with {OSM_NAME}</Button>
-      </section>
-    )
+    return <section className='page inner'>Loading...</section>
   }
 }
 


### PR DESCRIPTION
This simplifies the login page by redirecting from the login provider
straight to the oauth2 identity provider. This works because the only
identity provider we have is OSM.

Note: This might be a bit complicated if a user is logged into OSM with
a different account than they want associated with teams. Usually the
flow would surface something like "previously you've logged in with
account x, do you want to proceed?" but this is an edge case for users
with multiple OSM accounts.

Testing: 
1. Delete all session cookies from the localhost of osm-teams and try the "sign in" login flow. Instead of taking you to the "Login with OSM" page, it should take you to openstreetmap directly then back to the application. 
2. Delete all session cookies for osm teams and your access token from scoreboard, then test "connect your teams" flow. There should be one less screen (the login with OSM) page.