### PR TITLE
shell scripts for organization management

### DIFF
--- a/bin/managers.sh
+++ b/bin/managers.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -e
+
+#
+# manage osm-teams organization managers via psql.
+#
+
+show_help() {
+  cat << __HELP__
+  owners.sh
+
+  add or remove managers from osm-teams
+
+  -o | --org-id : organization id to operate on
+  -u | --user-id : osm/mapedit user id to add/remove
+  -r | --remove : remove the user from managers list
+
+  example:
+
+  ./managers.sh --user-id 0912311 --org-id 1
+  ./managers.sh --remove --user-id 0912311 --org-id 1
+
+__HELP__
+}
+
+die() {
+    printf '%s\n' "$1" >&2
+    exit 1
+}
+
+
+if [ -z "$DSN" ]; then
+  die "error: DSN for postgreql database is missing"
+fi
+
+uid=
+oid=
+remove=
+
+while :; do
+    case $1 in
+        -h|-\?|--help)
+          show_help
+          exit
+          ;;
+        -u|--user-id)
+          if [ "$2" ]; then
+              uid=$2
+              shift
+          else
+              die 'error: "--user-id" requires a non-empty option argument.'
+          fi
+          ;;
+        -o|--org-id)
+          if [ "$2" ]; then
+            oid=$2
+            shift
+          else
+              die 'error: "--org-id" requires a non-empty option argument.'
+          fi
+          ;;
+        -r|--remove)
+            remove=1
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -?*)
+            printf 'warn: Unknown option (ignored): %s\n' "$1" >&2
+            ;;
+        *)               # Default case: No more options, so break out of the loop.
+            break
+    esac
+    shift
+done
+
+if [ -z "$uid" ]; then
+    die "missing --user-id of osm/mapedit user to add/remove"
+fi
+
+if [ -z "$oid" ]; then
+    die "missing --org-id of organization to modify"
+fi
+
+if [ -z "$remove" ]; then
+  psql $DSN --command "insert into organization_manager (organization_id, osm_id) values ($oid, $uid)"
+else
+  psql $DSN --command "delete from organization_manager where organization_id = $oid and osm_id = $uid"
+fi
+
+psql $DSN --command "select * from organization_manager"

--- a/bin/managers.sh
+++ b/bin/managers.sh
@@ -7,7 +7,7 @@ set -e
 
 show_help() {
   cat << __HELP__
-  owners.sh
+  managers.sh
 
   add or remove managers from osm-teams
 

--- a/bin/organizations.sh
+++ b/bin/organizations.sh
@@ -81,7 +81,9 @@ if [ -z "$name" ]; then
 fi
 
 if [ -z "$remove" ]; then
-  psql $DSN --command "insert into organization (name, description) values ('$name', '$description')"
+  org_id=`psql $DSN -t --command "insert into organization (name, description) values ('$name', '$description') returning id"`
+  echo "created organization id: ${org_id}"
+  echo
 else
   psql $DSN --command "delete from organization where name = '$name'"
 fi

--- a/bin/organizations.sh
+++ b/bin/organizations.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -e
+
+#
+# manage osm-teams organizations via psql.
+#
+
+show_help() {
+  cat << __HELP__
+  organizations.sh
+
+  add or remove organizations from osm-teams
+
+  -n | --name : organization name to add/remove
+  -d | --description : organization description to add (optional)
+  -r | --remove : remove the organization (requires --name)
+
+  example:
+
+  ./organizations.sh --name "my org" --description "foo"
+  ./organizations.sh --remove --name "my org"
+
+__HELP__
+}
+
+die() {
+    printf '%s\n' "$1" >&2
+    exit 1
+}
+
+
+if [ -z "$DSN" ]; then
+  die "error: DSN for postgreql database is missing"
+fi
+
+name=
+description=
+remove=
+
+while :; do
+    case $1 in
+        -h|-\?|--help)
+            show_help
+            exit
+            ;;
+        -n|--name)
+          if [ "$2" ]; then
+              name=$2
+              shift
+          else
+              die 'error: "--name" requires a non-empty option argument.'
+          fi
+          ;;
+
+        -d|--description)
+            if [ "$2" ]; then
+                description=$2
+                shift
+            else
+                die 'error: "--description" requires a non-empty option argument.'
+            fi
+            ;;
+        -r|--remove)
+            remove=1
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -?*)
+            printf 'warn: Unknown option (ignored): %s\n' "$1" >&2
+            ;;
+        *)               # Default case: No more options, so break out of the loop.
+            break
+    esac
+    shift
+done
+
+if [ -z "$name" ]; then
+    die "missing --name of organization to add/remove"
+fi
+
+if [ -z "$remove" ]; then
+  psql $DSN --command "insert into organization (name, description) values ('$name', '$description')"
+else
+  psql $DSN --command "delete from organization where name = '$name'"
+fi
+
+psql $DSN --command "select * from organization"

--- a/bin/owners.sh
+++ b/bin/owners.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -e
+
+#
+# manage osm-teams organization owners via psql queries
+#
+
+show_help() {
+  cat << __HELP__
+  owners.sh
+
+  add or remove owners from osm-teams
+
+  -o | --org-id : organization id to operate on
+  -u | --user-id : osm/mapedit user id to add/remove
+  -r | --remove : remove the user from owners list
+
+  example:
+
+  ./owners.sh --user-id 0912311 --org-id 1
+  ./owners.sh --remove --user-id 0912311 --org-id 1
+
+__HELP__
+}
+
+die() {
+    printf '%s\n' "$1" >&2
+    exit 1
+}
+
+
+if [ -z "$DSN" ]; then
+  die "error: DSN for postgreql database is missing"
+fi
+
+uid=
+oid=
+remove=
+
+while :; do
+    case $1 in
+        -h|-\?|--help)
+          show_help
+          exit
+          ;;
+        -u|--user-id)
+          if [ "$2" ]; then
+              uid=$2
+              shift
+          else
+              die 'error: "--user-id" requires a non-empty option argument.'
+          fi
+          ;;
+        -o|--org-id)
+          if [ "$2" ]; then
+            oid=$2
+            shift
+          else
+              die 'error: "--org-id" requires a non-empty option argument.'
+          fi
+          ;;
+        -r|--remove)
+            remove=1
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -?*)
+            printf 'warn: Unknown option (ignored): %s\n' "$1" >&2
+            ;;
+        *)               # Default case: No more options, so break out of the loop.
+            break
+    esac
+    shift
+done
+
+if [ -z "$uid" ]; then
+    die "missing --user-id of osm/mapedit user to add/remove"
+fi
+
+if [ -z "$oid" ]; then
+    die "missing --org-id of organization to modify"
+fi
+
+if [ -z "$remove" ]; then
+  psql $DSN --command "insert into organization_owner (organization_id, osm_id) values ($oid, $uid)"
+else
+  psql $DSN --command "delete from organization_owner where organization_id = $oid and osm_id = $uid"
+fi
+
+psql $DSN --command "select * from organization_owner"


### PR DESCRIPTION
Add bash scripts for add+remove of organizations, org owners, and org managers.

Closes #177

### test in local dev environment

```bash
export DSN=postgres://postgres@localhost/osm-teams?sslmode=disable
./organizations ...
./owners ...
./managers ...
```
