### PR TITLE
Update hydra

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - URLS_SELF_ISSUER=http://localhost:4444
       - URLS_CONSENT=http://localhost:8989/oauth/consent
       - URLS_LOGIN=http://localhost:8989/oauth/login
+      - TTL_REFRESH_TOKEN="-1"
+      - TTL_ACCESS_TOKEN="720h"
     env_file:
       .env
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   hydra:
-    image: oryd/hydra:v1
+    image: oryd/hydra:v1.4
     ports:
     - 4444:4444
     - 4445:4445


### PR DESCRIPTION
Required for https://github.com/developmentseed/scoreboard/pull/613

needs a `docker-compose run hydra migrate sql $DSN` after upgrade. 