### PR TITLE
Fix API 404 status, add API docs instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 Check the beta 👉 <!-- markdownlint-disable MD034 -->https://mapping.team
 <!-- markdownlint-enable MD034 -->
 
+API Docs: https://mapping.team/api/docs
+
 ## Development
 
 Install requirements:
@@ -71,6 +73,7 @@ Start development server:
 ✨ You can now login to the app at http://localhost:8989
 <!-- markdownlint-enable MD034 -->
 
+Local API documentation will be available at http://localhost:8989/api/docs.
 ## Acknowledgments
 
 - This app is based off of [OSM/Hydra](https://github.com/kamicut/osmhydra)

--- a/app/index.js
+++ b/app/index.js
@@ -41,7 +41,7 @@ async function init () {
   /**
    * Docs endpoints
    */
-  app.use(['/api', '/api/docs'], swaggerUi.serve, swaggerUi.setup(swaggerDocument))
+  app.use(['/api/docs'], swaggerUi.serve, swaggerUi.setup(swaggerDocument))
 
   /**
    * Handle all other route GET with nextjs

--- a/app/manage/organizations.js
+++ b/app/manage/organizations.js
@@ -147,7 +147,7 @@ async function destroyOrg (req, reply) {
 
   try {
     await organization.destroy(id)
-    reply.sendStatus(200)
+    return reply.sendStatus(200)
   } catch (err) {
     console.log(err)
     return reply.boom.badRequest(err.message)

--- a/app/tests/api/badges-api.test.js
+++ b/app/tests/api/badges-api.test.js
@@ -76,7 +76,7 @@ test.before(async () => {
 
   // Add team member
   await orgOwner.agent
-    .put(`/api/team/${orgTeam1.id}/${orgTeamMember.id}`)
+    .put(`/api/teams/add/${orgTeam1.id}/${orgTeamMember.id}`)
     .expect(200)
 
   // Add manager

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
   "license": "MIT",
   "scripts": {
     "docs:validate": "swagger-cli validate docs/api.yml",
-    "docs:api": "swagger-markdown -i docs/api.yml -o docs/api.md",
-    "docs": "npm run docs:validate && npm run docs:api",
     "dev": "NODE_ENV=development nodemon --watch app app/index.js",
     "migrate": "knex --knexfile app/db/knexfile.js migrate:latest",
     "test": "NODE_ENV=test nyc ava app/tests/**/*.test.js -c 1 --serial --verbose",


### PR DESCRIPTION
## What I am changing

Currently the API will never return 404 for inexisting routes because of Swagger configuration. We are also missing instructions on how to see the API docs.

## How I did it

Changes:

- Updated README
- Remove serving Swagger from `/api`, which causes `/api/not-existing-route` to return 200
- Updated a spec to fix a route
- Removed docs tasks from package.json, which looks unnecessary

## How you can test it

- Run locally from develop, access http://localhost:8989/api/not-existing-route, it will return 200 and display docs
- Run from this branch, access the route again, should return 404

## Related Issues

- #254