### PR TITLE
Add empty state to table component

### DIFF
--- a/components/table.js
+++ b/components/table.js
@@ -46,29 +46,25 @@ function Row ({ columns, row, index, onRowClick }) {
 function TableBody ({ columns, rows, onRowClick, emptyPlaceHolder }) {
   return (
     <tbody className='lh-copy'>
-      {
-        !rows || rows.length === 0 ? <tr
-        >
-          <td
-            key={`row-empty`}
-            colSpan={columns.length}
-          >
+      {!rows || rows.length === 0 ? (
+        <tr>
+          <td key='empty-row' colSpan={columns.length}>
             {emptyPlaceHolder || 'No data available.'}
           </td>
-
         </tr>
-          : rows.map((row, index) => {
-            return (
-              <Row
-                key={`row-${index}`}
-                columns={columns}
-                row={row}
-                index={index}
-                onRowClick={onRowClick}
-              />
-            )
-          })
-      }
+      ) : (
+        rows.map((row, index) => {
+          return (
+            <Row
+              key={`row-${index}`}
+              columns={columns}
+              row={row}
+              index={index}
+              onRowClick={onRowClick}
+            />
+          )
+        })
+      )}
     </tbody>
   )
 }

--- a/components/table.js
+++ b/components/table.js
@@ -43,34 +43,41 @@ function Row ({ columns, row, index, onRowClick }) {
   )
 }
 
-function TableBody ({ columns, rows, onRowClick }) {
+function TableBody ({ columns, rows, onRowClick, emptyPlaceHolder }) {
   return (
     <tbody className='lh-copy'>
       {
-        rows.map((row, index) => {
-          return (
-            <Row
-              key={`row-${index}`}
-              columns={columns}
-              row={row}
-              index={index}
-              onRowClick={onRowClick}
-            />
-          )
-        })
+        !rows || rows.length === 0 ? <tr
+        >
+          <td
+            key={`row-empty`}
+            colSpan={columns.length}
+          >
+            {emptyPlaceHolder || 'No data available.'}
+          </td>
+
+        </tr>
+          : rows.map((row, index) => {
+            return (
+              <Row
+                key={`row-${index}`}
+                columns={columns}
+                row={row}
+                index={index}
+                onRowClick={onRowClick}
+              />
+            )
+          })
       }
     </tbody>
   )
 }
 
-export default function Table ({ columns, rows, onRowClick }) {
-  if (!rows || !columns) {
-    return <div />
-  }
+export default function Table ({ columns, rows, onRowClick, emptyPlaceHolder }) {
   return (
     <table>
       <TableHead columns={columns} />
-      <TableBody columns={columns} rows={rows} onRowClick={onRowClick} />
+      <TableBody columns={columns} rows={rows} onRowClick={onRowClick} emptyPlaceHolder={emptyPlaceHolder} />
       <style jsx global>
         {`
           table {

--- a/pages/organization.js
+++ b/pages/organization.js
@@ -150,13 +150,16 @@ export default class Organization extends Component {
       }
     })
 
-    return <Table
-      rows={allRows}
-      columns={columns}
-      onRowClick={
-        (row) => this.openProfileModal(row)
-      }
-    />
+    return (
+      <Table
+        rows={allRows}
+        columns={columns}
+        emptyPlaceHolder={
+          this.state.loading ? 'Loading...' : 'This organization has no staff.'
+        }
+        onRowClick={(row) => this.openProfileModal(row)}
+      />
+    )
   }
 
   renderMembers (memberRows) {
@@ -164,14 +167,18 @@ export default class Organization extends Component {
       { key: 'id' },
       { key: 'name' }
     ]
-    return <Table
-      rows={memberRows}
-      columns={columns}
-      emptyPlaceHolder={this.state.loading ? 'Loading...' : 'This organization has no members.'}
-      onRowClick={
-        (row) => this.openProfileModal(row)
-      }
-    />
+    return (
+      <Table
+        rows={memberRows}
+        columns={columns}
+        emptyPlaceHolder={
+          this.state.loading
+            ? 'Loading...'
+            : 'This organization has no members.'
+        }
+        onRowClick={(row) => this.openProfileModal(row)}
+      />
+    )
   }
 
   render () {

--- a/pages/organization.js
+++ b/pages/organization.js
@@ -167,6 +167,7 @@ export default class Organization extends Component {
     return <Table
       rows={memberRows}
       columns={columns}
+      emptyPlaceHolder={this.state.loading ? 'Loading...' : 'This organization has no members.'}
       onRowClick={
         (row) => this.openProfileModal(row)
       }
@@ -293,7 +294,7 @@ export default class Organization extends Component {
                 </div>
               </div>
             </Section>
-            {!this.state.loading ? this.renderMembers(members) : 'Loading...'}
+            {this.renderMembers(members)}
           </div>
         ) : <div />}
         <Modal style={{


### PR DESCRIPTION
## What I am changing

If no data is passed to the table component it will render only the header (with no rows), which is not desirable. In this PR the table component is changed to display a empty state message if no data is passed. As this message is customizable, it is possible to pass a 'Loading...' message when the data is being fetched.

## How I did it

Added a <td> containing `emptyStateMessage` that spans to all columns when no data is available.

## How you can test it

At the moment this is applied only to organization page, which can be tested by visiting it. Other tables should keep working as before, but now displaying "No data available" if no rows are available. We should use this elsewhere if necessary.

## Related Issues

There was no ticket for this bug.