### PR TITLE
Improve badge assignment, add badge unassignment

### DIFF
--- a/app/manage/badges.js
+++ b/app/manage/badges.js
@@ -329,7 +329,10 @@ const removeUserBadge = routeWrapper({
         badge_id: req.params.badgeId
       })
 
-      reply.sendStatus(200)
+      return reply.send({
+        status: 200,
+        message: `Badge ${req.params.badgeId} unassigned successfully.`
+      })
     } catch (err) {
       console.log(err)
       return reply.boom.badRequest(err.message)

--- a/app/manage/index.js
+++ b/app/manage/index.js
@@ -301,12 +301,19 @@ function manageRouter (nextApp) {
       })
     }
   )
+
+  // Use same page for two routes
+  const assignBadgePageRoute = [
+    can('organization:edit'),
+    (req, res) => nextApp.render(req, res, '/badges/assign', req.params)
+  ]
+  router.get(
+    '/organizations/:id/badges/assign/:userId',
+    ...assignBadgePageRoute
+  )
   router.get(
     '/organizations/:id/badges/:badgeId/assign/:userId',
-    can('organization:edit'),
-    (req, res) => {
-      return nextApp.render(req, res, '/badges/assign', req.params)
-    }
+    ...assignBadgePageRoute
   )
 
   return router

--- a/pages/organization.js
+++ b/pages/organization.js
@@ -335,13 +335,16 @@ export default class Organization extends Component {
               this.getOrg()
             }
           })
-          profileActions.push({
-            name: 'Assign a Badge',
-            onClick: () => Router.push(
-              join(URL, `/organizations/${org.id}/badges/assign/${profileId}`)
-            )
-          })
         }
+      }
+
+      if (isProfileManager || isProfileOwner) {
+        profileActions.push({
+          name: 'Assign a Badge',
+          onClick: () => Router.push(
+            join(URL, `/organizations/${org.id}/badges/assign/${profileId}`)
+          )
+        })
       }
     }
 

--- a/pages/organization.js
+++ b/pages/organization.js
@@ -335,6 +335,12 @@ export default class Organization extends Component {
               this.getOrg()
             }
           })
+          profileActions.push({
+            name: 'Assign a Badge',
+            onClick: () => Router.push(
+              join(URL, `/organizations/${org.id}/badges/assign/${profileId}`)
+            )
+          })
         }
       }
     }


### PR DESCRIPTION
Contributes to #240. Changes:

- Add "Assign a badge" action in profile page actions (when clicked in organization page)
- Badge assignment page allow selecting which badge to apply
- Badge assignment page now includes a button to unassign a badge

How to test: 

- Assign a badge: go to an organization page that has badges, click any member/staff user, click gear button, select "Assign a badge". This will redirect to the badge assignment page, then select a badge and click assign button. 
- Unassign a badge: in the organization page, click the badge assigned to the user, at badge page click user in assigned members table, hit unassign button at badge assignment page

Know issues:
- Workflow to update/remove badge is not ideal, we should list assigned badges in user profile and link it to the badge assignment page
- When a badge doesn't have any assigned members, badge view page should display an empty table (not blank space)
- We should probably remove assignment by osm id at the badge page(?)

@kamicut ready for review.