### PR TITLE
Invite Links

### DIFF
--- a/app/db/migrations/20220415114820_invitations.js
+++ b/app/db/migrations/20220415114820_invitations.js
@@ -1,0 +1,13 @@
+
+exports.up = async function (knex) {
+  return knex.schema.createTable('invitations', table => {
+    table.string('id')
+    table.integer('team_id').references('id').inTable('team').onDelete('CASCADE')
+    table.timestamp('created_at').defaultTo(knex.fn.now())
+    table.timestamp('expires_at').nullable()
+  })
+};
+
+exports.down = async function (knex) {
+  return knex.schema.dropTable('invitations')
+};

--- a/app/db/migrations/20220415114820_invitations.js
+++ b/app/db/migrations/20220415114820_invitations.js
@@ -6,8 +6,8 @@ exports.up = async function (knex) {
     table.timestamp('created_at').defaultTo(knex.fn.now())
     table.timestamp('expires_at').nullable()
   })
-};
+}
 
 exports.down = async function (knex) {
   return knex.schema.dropTable('invitations')
-};
+}

--- a/app/lib/team.js
+++ b/app/lib/team.js
@@ -3,7 +3,7 @@ const knexPostgis = require('knex-postgis')
 const join = require('url-join')
 const xml2js = require('xml2js')
 const { unpack } = require('./utils')
-const { prop } = require('ramda')
+const { prop, isEmpty } = require('ramda')
 const request = require('request-promise-native')
 
 const { serverRuntimeConfig } = require('../../next.config')
@@ -414,6 +414,16 @@ async function associatedOrg (teamId) {
   )
 }
 
+async function isInvitationValid (teamId, invitationId) {
+  if (!teamId) throw new Error('team id is required as first argument')
+  if (!invitationId) throw new Error('invitation id is required as second argument')
+
+  const conn = await db()
+  const invitations = await conn('invitations').where({ team_id: teamId, id: invitationId })
+
+  return !isEmpty(invitations)
+}
+
 module.exports = {
   get,
   list,
@@ -433,6 +443,7 @@ module.exports = {
   isModerator,
   isMember,
   isPublic,
+  isInvitationValid,
   resolveMemberNames,
   associatedOrg
 }

--- a/app/manage/index.js
+++ b/app/manage/index.js
@@ -24,7 +24,7 @@ const {
   getJoinInvitations,
   createJoinInvitation,
   deleteJoinInvitation,
-  acceptJoinInvitation,
+  acceptJoinInvitation
 } = require('./teams')
 
 const {
@@ -70,7 +70,7 @@ const {
 
 const { getUserManageToken } = require('../lib/profile')
 const orgModel = require('../lib/organization')
-const teamModel =require('../lib/team')
+const teamModel = require('../lib/team')
 
 /**
  * The manageRouter handles all routes related to the first party
@@ -124,7 +124,7 @@ function manageRouter (nextApp) {
   router.put('/api/teams/:id/join', can('team:join'), joinTeam)
   router.put('/api/teams/:id/assignModerator/:osmId', can('team:edit'), assignModerator)
   router.put('/api/teams/:id/removeModerator/:osmId', can('team:edit'), removeModerator)
-  
+
   /**
    * Manage inviations to teams
    */
@@ -306,7 +306,6 @@ function manageRouter (nextApp) {
   router.get('/organizations/:id/edit-team-profiles', can('organization:member'), (req, res) => {
     return nextApp.render(req, res, '/org-edit-team-profile', { id: req.params.id })
   })
-
 
   /**
    * Badge pages

--- a/app/manage/teams.js
+++ b/app/manage/teams.js
@@ -1,8 +1,13 @@
 const team = require('../lib/team')
+const db = require('../db')
+const yup = require('yup')
+const crypto = require('crypto')
+const { routeWrapper } = require('./utils')
 const { prop, map, dissoc } = require('ramda')
 const urlRegex = require('url-regex')
 const { teamsMembersModeratorsHelper } = require('./utils')
 const profile = require('../lib/profile')
+const { id } = require('date-fns/locale')
 
 const isUrl = urlRegex({ exact: true })
 const getOsmId = prop('osm_id')
@@ -253,6 +258,101 @@ async function removeMember (req, reply) {
   }
 }
 
+const getJoinInvitations = routeWrapper({
+  validate: {
+    params: yup.object({
+      id: yup.number().required().positive().integer()
+    }).required()
+  },
+  handler: async function (req, reply) {
+    try {
+      const conn = await db()
+      const invitations = await conn('invitations')
+        .select().where('team_id', req.params.id).orderBy('created_at', 'desc') // Most recent first
+
+      reply.send(invitations)
+    } catch (e) {
+      console.error(e)
+      reply.boom.badRequest(e.message)
+    }
+  }
+})
+
+const createJoinInvitation = routeWrapper({
+  validate: {
+    params: yup.object({
+      id: yup.number().required().positive().integer()
+    }).required()
+  },
+  handler: async function (req, reply) {
+    try {
+      const conn = await db()
+      const uuid = crypto.randomUUID()
+      const [invitation] = await conn('invitations').insert({
+        id: uuid,
+        team_id: req.params.id
+      }).returning('*')
+      reply.send(invitation)
+    } catch (err) {
+      console.log(err)
+      return reply.boom.badRequest(err.message)
+    }
+  }
+})
+
+const deleteJoinInvitation = routeWrapper({
+  validate: {
+    params: yup.object({
+      id: yup.number().required().positive().integer(),
+      uuid: yup.string().uuid().required()
+    }).required()
+  },
+  handler: async function (req, reply) {
+    try {
+      const conn = await db()
+      await conn('invitations').where({
+        team_id: req.params.id,
+        id: req.params.uuid
+      }).del()
+      reply.sendStatus(200)
+    } catch (err) {
+      console.log(err)
+      return reply.boom.badRequest(err.message)
+    }
+  }
+})
+
+const acceptJoinInvitation = routeWrapper({
+  validate: {
+    params: yup.object({
+      id: yup.number().required().positive().integer(),
+      uuid: yup.string().uuid().required()
+    }).required()
+  },
+  handler: async (req, reply) => {
+    const user = reply.locals.user_id
+    try {
+      const conn = await db()
+      const [invitation] = await conn('invitations').where({
+        team_id: req.params.id,
+        id: req.params.uuid
+      })
+
+      // If this invitation doesn't exist, then it's not valid
+      if (!invitation) {
+        return reply.sendStatus(404)
+      }
+      else {
+        team.addMember(req.params.id, user)
+        return reply.sendStatus(200)
+      }
+    } catch (err) {
+      console.log(err)
+      return reply.boom.badRequest(err.message)
+    }
+  }
+})
+
 async function joinTeam (req, reply) {
   const { id } = req.params
   const osmId = reply.locals.user_id
@@ -287,5 +387,9 @@ module.exports = {
   removeMember,
   removeModerator,
   updateMembers,
-  updateTeam
+  updateTeam,
+  getJoinInvitations,
+  createJoinInvitation,
+  deleteJoinInvitation,
+  acceptJoinInvitation
 }

--- a/app/manage/teams.js
+++ b/app/manage/teams.js
@@ -7,7 +7,6 @@ const { prop, map, dissoc } = require('ramda')
 const urlRegex = require('url-regex')
 const { teamsMembersModeratorsHelper } = require('./utils')
 const profile = require('../lib/profile')
-const { id } = require('date-fns/locale')
 
 const isUrl = urlRegex({ exact: true })
 const getOsmId = prop('osm_id')
@@ -341,8 +340,7 @@ const acceptJoinInvitation = routeWrapper({
       // If this invitation doesn't exist, then it's not valid
       if (!invitation) {
         return reply.sendStatus(404)
-      }
-      else {
+      } else {
         team.addMember(req.params.id, user)
         return reply.sendStatus(200)
       }

--- a/lib/teams-api.js
+++ b/lib/teams-api.js
@@ -222,3 +222,46 @@ export async function removeModerator (id, osmId) {
     }
   })
 }
+
+/**
+ * getTeamJoinInvitations
+ * Get invitation ids valid for this team
+ * @param {int} id - team id
+ * @returns {uuid[]} invitation ids
+ */
+export async function getTeamJoinInvitations (id) {
+  let res = await fetch(join(URL, `${id}`, 'invitations'))
+  if (res.status === 200) {
+    return res.json()
+  } else {
+    const err = new Error('could not retrieve team invitations')
+    err.status = res.status
+    throw err
+  }
+}
+
+export async function createTeamJoinInvitation (id) {
+  const res = await fetch(join(URL, `${id}`, 'invitations'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8'
+    }
+  })
+
+  if (res.status === 200) {
+    return res.json()
+  } else {
+    throw new Error('Could not retrieve teams')
+  }
+}
+
+export async function acceptTeamJoinInvitation(id, uuid) {
+  const res = await fetch(join(URL, `${id}`, 'invitations', `${uuid}`, 'accept'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8'
+    }
+  })
+
+  return res
+}

--- a/lib/teams-api.js
+++ b/lib/teams-api.js
@@ -255,7 +255,7 @@ export async function createTeamJoinInvitation (id) {
   }
 }
 
-export async function acceptTeamJoinInvitation(id, uuid) {
+export async function acceptTeamJoinInvitation (id, uuid) {
   const res = await fetch(join(URL, `${id}`, 'invitations', `${uuid}`, 'accept'), {
     method: 'POST',
     headers: {

--- a/pages/invitation.js
+++ b/pages/invitation.js
@@ -4,13 +4,13 @@ import Router from 'next/router'
 import getConfig from 'next/config'
 import { toast } from 'react-toastify'
 import Button from '../components/button'
-import { getTeam, getTeamJoinInvitations, acceptTeamJoinInvitation } from '../lib/teams-api'
+import { acceptTeamJoinInvitation } from '../lib/teams-api'
 
 const { publicRuntimeConfig } = getConfig()
 const URL = publicRuntimeConfig.APP_URL
 
 export default class Invitation extends Component {
-  static async getInitialProps({ query }) {
+  static async getInitialProps ({ query }) {
     if (query) {
       return {
         teamId: query.team_id,
@@ -36,7 +36,7 @@ export default class Invitation extends Component {
     })
   }
 
-  async rejectInvitation() {
+  async rejectInvitation () {
     Router.push(URL)
   }
 
@@ -49,7 +49,7 @@ export default class Invitation extends Component {
       }
       this.setState({
         invitationSuccess: true,
-        invitationPending: false,
+        invitationPending: false
       })
     } catch (err) {
       console.error(err)
@@ -60,7 +60,7 @@ export default class Invitation extends Component {
     }
   }
 
-  render() {
+  render () {
     const { team, error } = this.state
     if (error) {
       if (error.status === 401 || error.status === 403) {
@@ -87,21 +87,28 @@ export default class Invitation extends Component {
     if (!team) return null
     return (
       <article className='inner page'>
-          You have been invited to join <b>{team.name}</b>
-          <br />
-          <br />
-          { this.state.invitationPending ? 
+        You have been invited to join <b>{team.name}</b>
+        <br />
+        <br />
+        {this.state.invitationPending ? (
           <>
-            <Button variant='submit' onClick={() => this.acceptInvitation()}>Accept</Button>
-            <span style={{ marginLeft: '1rem' }}><Button onClick={() => this.rejectInvitation()}>Cancel</Button></span>
+            <Button variant='submit' onClick={() => this.acceptInvitation()}>
+              Accept
+            </Button>
+            <span style={{ marginLeft: '1rem' }}>
+              <Button onClick={() => this.rejectInvitation()}>Cancel</Button>
+            </span>
           </>
-          : ''
-          }
-          {
-            this.state.invitationSuccess ?
-            <Button variant='submit' href={join(URL, 'teams',`${team.id}`)}>Go to your team</Button>
-            : ''
-          }
+        ) : (
+          ''
+        )}
+        {this.state.invitationSuccess ? (
+          <Button variant='submit' href={join(URL, 'teams', `${team.id}`)}>
+            Go to your team
+          </Button>
+        ) : (
+          ''
+        )}
       </article>
     )
   }

--- a/pages/invitation.js
+++ b/pages/invitation.js
@@ -1,0 +1,108 @@
+import React, { Component } from 'react'
+import join from 'url-join'
+import Router from 'next/router'
+import getConfig from 'next/config'
+import { toast } from 'react-toastify'
+import Button from '../components/button'
+import { getTeam, getTeamJoinInvitations, acceptTeamJoinInvitation } from '../lib/teams-api'
+
+const { publicRuntimeConfig } = getConfig()
+const URL = publicRuntimeConfig.APP_URL
+
+export default class Invitation extends Component {
+  static async getInitialProps({ query }) {
+    if (query) {
+      return {
+        teamId: query.team_id,
+        invitationId: query.invitation_id,
+        team: query.team
+      }
+    }
+  }
+
+  constructor (props) {
+    super(props)
+    this.state = {
+      invitationPending: true,
+      invitationSuccess: false,
+      error: undefined
+    }
+  }
+
+  async componentDidMount () {
+    const { team } = this.props
+    this.setState({
+      team
+    })
+  }
+
+  async rejectInvitation() {
+    Router.push(URL)
+  }
+
+  async acceptInvitation () {
+    const { teamId, invitationId } = this.props
+    try {
+      const res = await acceptTeamJoinInvitation(teamId, invitationId)
+      if (res.ok) {
+        toast.success('Success! You are now part of the team')
+      }
+      this.setState({
+        invitationSuccess: true,
+        invitationPending: false,
+      })
+    } catch (err) {
+      console.error(err)
+      toast.error('There was an error accepting this invitation')
+      this.setState({
+        invitationPending: false
+      })
+    }
+  }
+
+  render() {
+    const { team, error } = this.state
+    if (error) {
+      if (error.status === 401 || error.status === 403) {
+        return (
+          <article className='inner page'>
+            <h1>Unauthorized</h1>
+          </article>
+        )
+      } else if (error.status === 404) {
+        return (
+          <article className='inner page'>
+            <h1>This invitation was not found or has expired</h1>
+          </article>
+        )
+      } else {
+        return (
+          <article className='inner page'>
+            <h1>Error: {error.message}</h1>
+          </article>
+        )
+      }
+    }
+
+    if (!team) return null
+    return (
+      <article className='inner page'>
+          You have been invited to join <b>{team.name}</b>
+          <br />
+          <br />
+          { this.state.invitationPending ? 
+          <>
+            <Button variant='submit' onClick={() => this.acceptInvitation()}>Accept</Button>
+            <span style={{ marginLeft: '1rem' }}><Button onClick={() => this.rejectInvitation()}>Cancel</Button></span>
+          </>
+          : ''
+          }
+          {
+            this.state.invitationSuccess ?
+            <Button variant='submit' href={join(URL, 'teams',`${team.id}`)}>Go to your team</Button>
+            : ''
+          }
+      </article>
+    )
+  }
+}

--- a/pages/team.js
+++ b/pages/team.js
@@ -14,7 +14,7 @@ import AddMemberForm from '../components/add-member-form'
 import ProfileModal from '../components/profile-modal'
 import theme from '../styles/theme'
 
-import { getTeam, getTeamMembers, addMember, removeMember, joinTeam, assignModerator, removeModerator, 
+import { getTeam, getTeamMembers, addMember, removeMember, joinTeam, assignModerator, removeModerator,
   getTeamJoinInvitations, createTeamJoinInvitation } from '../lib/teams-api'
 import { getTeamProfile, getUserOrgProfile, getUserTeamProfile } from '../lib/profiles-api'
 import { toast } from 'react-toastify'
@@ -65,7 +65,7 @@ export default class Team extends Component {
     }
   }
 
-  async createJoinLink() {
+  async createJoinLink () {
     const { id } = this.props
     try {
       await createTeamJoinInvitation(id)
@@ -75,7 +75,6 @@ export default class Team extends Component {
       toast.error(e)
     }
   }
-
 
   async getTeam () {
     const { id } = this.props
@@ -325,14 +324,14 @@ export default class Team extends Component {
             }
             <SectionHeader>Location</SectionHeader>
             { this.renderMap(team.location) }
-            { isUserModerator ? 
-              <div style={{ marginTop: '1rem' }}>
+            { isUserModerator
+              ? <div style={{ marginTop: '1rem' }}>
                 <SectionHeader>Join Link</SectionHeader>
-                {joinLink ? <div>{joinLink}</div> :
-                  <Button onClick={() => this.createJoinLink()}>Create Join Link</Button>
+                {joinLink ? <div>{joinLink}</div>
+                  : <Button onClick={() => this.createJoinLink()}>Create Join Link</Button>
                 }
               </div>
-            : ''}
+              : ''}
           </Card>
         </div>
         <div className='team__table'>

--- a/pages/team.js
+++ b/pages/team.js
@@ -1,4 +1,6 @@
 import React, { Component } from 'react'
+import getConfig from 'next/config'
+import join from 'url-join'
 import { map, prop, contains, reverse, assoc } from 'ramda'
 import Modal from 'react-modal'
 import dynamic from 'next/dynamic'
@@ -12,8 +14,11 @@ import AddMemberForm from '../components/add-member-form'
 import ProfileModal from '../components/profile-modal'
 import theme from '../styles/theme'
 
-import { getTeam, getTeamMembers, addMember, removeMember, joinTeam, assignModerator, removeModerator } from '../lib/teams-api'
+import { getTeam, getTeamMembers, addMember, removeMember, joinTeam, assignModerator, removeModerator, 
+  getTeamJoinInvitations, createTeamJoinInvitation } from '../lib/teams-api'
 import { getTeamProfile, getUserOrgProfile, getUserTeamProfile } from '../lib/profiles-api'
+import { toast } from 'react-toastify'
+const { publicRuntimeConfig } = getConfig()
 
 const Map = dynamic(() => import('../components/team-map'), { ssr: false })
 
@@ -31,6 +36,7 @@ export default class Team extends Component {
     this.state = {
       profileInfo: [],
       profileUserId: '',
+      joinLink: null,
       loading: true,
       error: undefined
     }
@@ -40,7 +46,36 @@ export default class Team extends Component {
 
   async componentDidMount () {
     this.getTeam()
+    this.getTeamJoinLink()
   }
+
+  async getTeamJoinLink () {
+    const { id } = this.props
+    try {
+      const invitations = await getTeamJoinInvitations(id)
+      console.log(publicRuntimeConfig)
+      if (invitations.length) {
+        this.setState({
+          joinLink: join(publicRuntimeConfig.APP_URL, 'teams', id, 'invitations', invitations[0].id)
+        })
+      }
+    } catch (e) {
+      console.error(e)
+      toast.error(e)
+    }
+  }
+
+  async createJoinLink() {
+    const { id } = this.props
+    try {
+      await createTeamJoinInvitation(id)
+      this.getTeamJoinLink()
+    } catch (e) {
+      console.error(e)
+      toast.error(e)
+    }
+  }
+
 
   async getTeam () {
     const { id } = this.props
@@ -171,7 +206,7 @@ export default class Team extends Component {
   }
 
   render () {
-    const { team, error, teamProfile, teamMembers } = this.state
+    const { team, error, teamProfile, teamMembers, joinLink } = this.state
 
     if (error) {
       if (error.status === 401 || error.status === 403) {
@@ -290,6 +325,14 @@ export default class Team extends Component {
             }
             <SectionHeader>Location</SectionHeader>
             { this.renderMap(team.location) }
+            { isUserModerator ? 
+              <div style={{ marginTop: '1rem' }}>
+                <SectionHeader>Join Link</SectionHeader>
+                {joinLink ? <div>{joinLink}</div> :
+                  <Button onClick={() => this.createJoinLink()}>Create Join Link</Button>
+                }
+              </div>
+            : ''}
           </Card>
         </div>
         <div className='team__table'>
@@ -391,6 +434,7 @@ export default class Team extends Component {
 
             .team__table {
               grid-column: 1 / span 12;
+              padding-bottom: 2rem;
             }
           `}
         </style>


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- This PR introduces invitation links for teams so that moderators can send a URL to a user or group of users without having to add them by OSM ID.

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- I added a new page for "invitation request" that a logged-in user can accept
- In the teams settings, a moderator can "request an invite link" which will generate a UUID at the API level that corresponds to a valid invitation

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
1. Go to any team as a moderator and click on "Create invite link" which will generate a URL
2. With a secondary user, go to the newly created invite link and accept the invitation
3. The secondary user should now be part of the team

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- #81 is a similar issue
