### PR TITLE
fix login profile bug

### DIFF
--- a/app/lib/osm.js
+++ b/app/lib/osm.js
@@ -4,6 +4,7 @@
  * Route middleware to interact with OSM OAuth
  */
 const passport = require('passport-light')
+const R = require('ramda')
 const hydra = require('./hydra')
 const url = require('url')
 const db = require('../db')
@@ -55,11 +56,12 @@ function openstreetmap (req, res) {
     let conn = await db()
     let [user] = await conn('users').where('id', profile.id)
     if (user) {
+      const newProfile = R.mergeDeepRight(user.profile, profile)
       await conn('users').where('id', profile.id).update(
         {
           'osmToken': token,
           'osmTokenSecret': tokenSecret,
-          'profile': JSON.stringify(profile)
+          'profile': JSON.stringify(newProfile)
         }
       )
     } else {


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Fix login bug where a new login flow (after cookie expiry) would overwrite the profile of a user because they re-authenticated with OpenStreetMap

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- After re-authentication, we merge the incoming profile of the user with the profile in the database and continue the flow

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- We can force re-authentication with OpenStreetMap using two incognito windows. Try logging into one incognito window and filling out a team profile. In the second window, if you login again you should see the same profile values (they are not overwritten).

