### PR TITLE
Improve request error handling

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -58,6 +58,9 @@ async function init () {
    * Error handler
    */
   app.use(function (err, req, res, next) {
+    if (err.message === 'Forbidden') {
+      return nextApp.render(req, res, '/uh-oh')
+    }
     res.status(err.status || 500)
     console.error('error', err)
     res.boom.internal('An internal error occurred.')

--- a/app/manage/permissions/index.js
+++ b/app/manage/permissions/index.js
@@ -43,6 +43,10 @@ const permissions = mergeAll([
   organizationPermissions
 ])
 
+function isApiRequest ({ path }) {
+  return path.indexOf('/api') === 0
+}
+
 /**
  * Check if a user has a specific permission
  *
@@ -159,7 +163,11 @@ function check (ability) {
       if (allowed) {
         next()
       } else {
-        res.boom.unauthorized('Forbidden')
+        if (isApiRequest(req)) {
+          res.boom.unauthorized('Forbidden')
+        } else {
+          next(new Error('Forbidden'))
+        }
       }
     } catch (e) {
       console.error('error checking permission', e)

--- a/pages/uh-oh.js
+++ b/pages/uh-oh.js
@@ -1,0 +1,12 @@
+import React, { Component } from 'react'
+
+export default class UhOh extends Component {
+  render () {
+    return (
+      <article className='inner page'>
+        <h1>Page not found</h1>
+        <div>Sorry, the page you are looking for is not available.</div>
+      </article>
+    )
+  }
+}


### PR DESCRIPTION
Contributes to #410. This is work in progress.

The permissions middleware doesn't differentiate API and Web requests. For example, if `/organizations/1` is accessed in the browser and the user is not signed it or doesn't have permissions, a JSON error will be returned, as this request is treated as an API request.

In this PR I added a change to check if the request is API and, if not, to throw an error instead of returning a boom error. This will make NextJS general errors middleware to be called and the UhOh displayed. Please note this change is not applied to all API errors yet.

cc @kamicut 