### PR TITLE
Fix for org/teams API permissions

### DIFF
--- a/app/manage/index.js
+++ b/app/manage/index.js
@@ -151,7 +151,7 @@ function manageRouter (nextApp) {
   router.put('/api/organizations/:id/removeManager/:osmId', can('organization:edit'), removeManager)
 
   router.post('/api/organizations/:id/teams', can('organization:create-team'), createOrgTeam)
-  router.get('/api/organizations/:id/teams', getOrgTeams)
+  router.get('/api/organizations/:id/teams', can('organization:view-members'), getOrgTeams)
 
   /**
    * Manage organization badges


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Fix the API permissions for the `org/:id/teams` call

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- We add the `can('organization:view-members')` permission to this API call: if an org is public, you can view its teams and members, otherwise you have to be a member of the org

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Try calling the API for a private org with a non-org member

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- closes #274
