### PR TITLE
Permission fixes

### DIFF
--- a/app/manage/permissions/view-team-members.js
+++ b/app/manage/permissions/view-team-members.js
@@ -1,4 +1,5 @@
-const { isPublic, isMember } = require('../../lib/team')
+const { isPublic, isMember, associatedOrg } = require('../../lib/team')
+const { isOwner } = require('../../lib/organization')
 
 /**
  * team:view-members
@@ -15,7 +16,11 @@ async function viewTeamMembers (uid, { id }) {
   if (publicTeam) return publicTeam
 
   try {
-    return await isMember(id, uid)
+    const org = await associatedOrg(id)
+    const ownerOfTeam = org && (await isOwner(org.organization_id, uid))
+
+    // You can view the members if you're part of the team, or in case of an org team if you're the owner
+    return ownerOfTeam || await isMember(id, uid)
   } catch (e) {
     return false
   }

--- a/pages/invitation.js
+++ b/pages/invitation.js
@@ -85,6 +85,12 @@ export default class Invitation extends Component {
     }
 
     if (!team) return null
+    const userId = this.props.user.uid
+    if (!userId) {
+      return <article className='inner page'>
+        You are not logged in. Sign in and come back to this link.
+      </article>
+    }
     return (
       <article className='inner page'>
         You have been invited to join <b>{team.name}</b>

--- a/pages/login.js
+++ b/pages/login.js
@@ -16,7 +16,7 @@ class Login extends Component {
     const OSM_NAME = publicRuntimeConfig.OSM_NAME
     return (
       <section className='inner page'>
-        <h1>Login Provider</h1>
+        <h1>Login</h1>
         <p>Teams uses {OSM_NAME} as your login, connect your {OSM_NAME} account!</p>
         <br />
         <Button href={`/oauth/openstreetmap?login_challenge=${this.props.challenge}`}>Login with {OSM_NAME}</Button>


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Fixes invitation link page where it would let you click on "join a team" if you're not logged in
- Fix permission where an organization owner cannot view members of a private team within an org


