### PR TITLE
Fix access of team moderator to profile keys

### DIFF
--- a/app/lib/organization.js
+++ b/app/lib/organization.js
@@ -266,6 +266,20 @@ async function isMemberOrStaff (organizationId, osmId) {
 }
 
 /**
+ * Checks if an osmId is a moderator of any team inside the org
+ * @param {int} organizationId - organization id
+ * @param {int} osmId - id of member we are testing
+ */
+async function isOrgTeamModerator (organizationId, osmId) {
+  if (!organizationId) throw new PropertyRequiredError('organization id')
+  if (!osmId) throw new PropertyRequiredError('osm id')
+  const conn = await db()
+  const subquery = conn('organization_team').select('team_id').where('organization_id', organizationId)
+  const isModeratorOfAny = await conn('moderator').whereIn('team_id', subquery).debug()
+  return isModeratorOfAny.length > 0
+}
+
+/**
  * Checks if the osm user is an owner of a team
  * @param {int} organizationId - organization id
  * @param {int} osmId - osm id
@@ -350,6 +364,7 @@ module.exports = {
   isOwner,
   isManager,
   isMember,
+  isOrgTeamModerator,
   createOrgTeam,
   listMyOrganizations,
   getOrgStaff,

--- a/app/manage/index.js
+++ b/app/manage/index.js
@@ -221,7 +221,7 @@ function manageRouter (nextApp) {
   router.get('/api/profiles/keys/organizations/:id', can('organization:edit'), getProfileKeys('org', 'org'))
   router.post('/api/profiles/keys/organizations/:id', can('organization:edit'), createProfileKeys('org', 'org'))
 
-  router.get('/api/profiles/keys/organizations/:id/teams', can('organization:edit'), getProfileKeys('org', 'team'))
+  router.get('/api/profiles/keys/organizations/:id/teams', can('organization:view-team-keys'), getProfileKeys('org', 'team'))
   router.post('/api/profiles/keys/organizations/:id/teams', can('organization:edit'), createProfileKeys('org', 'team'))
 
   router.get('/api/profiles/keys/organizations/:id/users', can('organization:member'), getProfileKeys('org', 'user'))

--- a/app/manage/permissions/index.js
+++ b/app/manage/permissions/index.js
@@ -26,7 +26,8 @@ const organizationPermissions = {
   'organization:edit': require('./edit-org'),
   'organization:create-team': require('./create-org-team'),
   'organization:member': require('./member-org'),
-  'organization:view-members': require('./view-org-members')
+  'organization:view-members': require('./view-org-members'),
+  'organization:view-team-keys': require('./view-org-team-keys')
 }
 
 const clientPermissions = {

--- a/app/manage/permissions/view-org-team-keys.js
+++ b/app/manage/permissions/view-org-team-keys.js
@@ -1,0 +1,19 @@
+const { isOwner, isOrgTeamModerator } = require('../../lib/organization')
+
+/**
+ * organization:view-team-keys
+ *
+ * To edit an organization or delete it, the authenticated user needs
+ * to be an owner in the organization
+ *
+ * @param {int} uid - user id
+ * @param {Object} params - request parameters
+ * @param {int} params.id - organization id
+ * @returns {Promise<boolean>}
+ */
+async function editOrg (uid, { id }) {
+  const teamModerator = await isOrgTeamModerator(id, uid)
+  return teamModerator || isOwner(id, uid)
+}
+
+module.exports = editOrg

--- a/components/edit-team-form.js
+++ b/components/edit-team-form.js
@@ -29,7 +29,7 @@ function renderErrors (errors) {
   })
 }
 
-export default function EditTeamForm ({ initialValues, onSubmit, staff, isCreateForm, extraTags = [], profileValues }) {
+export default function EditTeamForm ({ initialValues, onSubmit, staff, isCreateForm, orgTeamTags = [], teamTags = [], profileValues }) {
   if (profileValues) {
     initialValues.tags = {}
     profileValues.forEach(({ id, value }) => {
@@ -42,14 +42,34 @@ export default function EditTeamForm ({ initialValues, onSubmit, staff, isCreate
       onSubmit={onSubmit}
       render={({ status, isSubmitting, submitForm, values, errors, setFieldValue, setErrors, setStatus }) => {
         let uniqueOrgs
-        let extraFields
+        let extraOrgTeamFields = []
+        let extraTeamFields = []
         if (staff && isCreateForm) {
           uniqueOrgs = uniqBy(prop('organization_id'), staff.map(({ name, organization_id }) => {
             return { name, organization_id }
           }))
         }
-        if (extraTags.length > 0) {
-          extraFields = extraTags.map(({ id, name, required, description }) => {
+        if (orgTeamTags.length > 0) {
+          extraOrgTeamFields = orgTeamTags.map(({ id, name, required, description }) => {
+            return (
+              <div className='form-control form-control__vertical' key={`extra-tag-${id}`}>
+                <label htmlFor={`extra-tag-${id}`}>{name}
+                  {required ? <span className='form--required'>*</span> : ''}
+                  {description ? descriptionPopup(description) : ''}
+                </label>
+                <Field
+                  type='text'
+                  name={`tags.key-${id}`}
+                  required={required}
+                  value={values.tags[`key-${id}`]}
+                />
+              </div>
+            )
+          })
+        }
+
+        if (teamTags.length > 0) {
+          extraTeamFields = teamTags.map(({ id, name, required, description }) => {
             return (
               <div className='form-control form-control__vertical' key={`extra-tag-${id}`}>
                 <label htmlFor={`extra-tag-${id}`}>{name}
@@ -112,10 +132,17 @@ export default function EditTeamForm ({ initialValues, onSubmit, staff, isCreate
               )
               : ''
             }
-            {extraTags.length > 0
+            {extraOrgTeamFields.length > 0
               ? <>
                 <h2>Org Attributes</h2>
-                {extraFields}
+                {extraOrgTeamFields}
+              </>
+              : ''
+            }
+            {extraTeamFields.length > 0
+              ? <>
+                <h2>Other Team Attributes</h2>
+                {extraTeamFields}
               </>
               : ''
             }

--- a/lib/profiles-api.js
+++ b/lib/profiles-api.js
@@ -71,6 +71,28 @@ export async function getOrgTeamAttributes (id) {
 }
 
 /**
+ * getTeamAttributess
+ * Get attributes for team attributes
+ *
+ * @returns {Array[Object]} - list of team details
+ */
+export async function getTeamAttributes (id) {
+  let res = await fetch(join(URL, 'keys', 'teams', `${id}`), {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8'
+    }
+  })
+  if (res.status === 200) {
+    return res.json()
+  } else {
+    const err = new Error('could not retrieve team member attributes')
+    err.status = res.status
+    throw err
+  }
+}
+
+/**
  * modifyAttribute
  * Modify attribute given a profile key
  *

--- a/pages/team-edit.js
+++ b/pages/team-edit.js
@@ -7,7 +7,7 @@ import getConfig from 'next/config'
 import EditTeamForm from '../components/edit-team-form'
 import Button from '../components/button'
 import theme from '../styles/theme'
-import { getOrgTeamAttributes, getTeamProfile } from '../lib/profiles-api'
+import { getTeamAttributes, getTeamProfile } from '../lib/profiles-api'
 const { publicRuntimeConfig } = getConfig()
 
 export default class TeamEdit extends Component {
@@ -32,12 +32,9 @@ export default class TeamEdit extends Component {
     const { id } = this.props
     try {
       let team = await getTeam(id)
-      let teamAttributes = []
+      let teamAttributes = await getTeamAttributes(id)
       let profileValues = []
       profileValues = await getTeamProfile(id)
-      if (team.org) {
-        teamAttributes = await getOrgTeamAttributes(team.org.organization_id)
-      }
       this.setState({
         team,
         profileValues,

--- a/pages/team-edit.js
+++ b/pages/team-edit.js
@@ -7,7 +7,7 @@ import getConfig from 'next/config'
 import EditTeamForm from '../components/edit-team-form'
 import Button from '../components/button'
 import theme from '../styles/theme'
-import { getTeamAttributes, getTeamProfile } from '../lib/profiles-api'
+import { getOrgTeamAttributes, getTeamAttributes, getTeamProfile } from '../lib/profiles-api'
 const { publicRuntimeConfig } = getConfig()
 
 export default class TeamEdit extends Component {
@@ -32,13 +32,18 @@ export default class TeamEdit extends Component {
     const { id } = this.props
     try {
       let team = await getTeam(id)
-      let teamAttributes = await getTeamAttributes(id)
+      let teamAttributes = await getTeamAttributes(id) || []
+      let orgTeamAttributes = []
       let profileValues = []
       profileValues = await getTeamProfile(id)
+      if (team.org) {
+        orgTeamAttributes = await getOrgTeamAttributes(team.org.organization_id)
+      }
       this.setState({
         team,
         profileValues,
         teamAttributes,
+        orgTeamAttributes,
         loading: false
       })
     } catch (e) {
@@ -109,7 +114,7 @@ export default class TeamEdit extends Component {
   }
 
   render () {
-    const { team, error, teamAttributes, profileValues } = this.state
+    const { team, error, teamAttributes, orgTeamAttributes, profileValues } = this.state
 
     if (error) {
       if (error.status >= 400 && error.status < 500) {
@@ -139,7 +144,8 @@ export default class TeamEdit extends Component {
           <EditTeamForm
             initialValues={pick(['name', 'bio', 'hashtag', 'editing_policy', 'location', 'privacy'], team)}
             profileValues={profileValues}
-            extraTags={teamAttributes}
+            teamTags={teamAttributes}
+            orgTeamTags={orgTeamAttributes}
             onSubmit={async (values, actions) => {
               try {
                 let tags = Object.keys(values.tags).map(key => {


### PR DESCRIPTION
Contributes to #286. I was able to replicate the error by adding a moderator user that is not part of the organization. If the user is part of the org, team profile editing works.

How to test:

- Create a org
- Add team to org
- Add a moderador user to team and not to the org
- Visit team edit page with moderador user, they should be able to edit profile

cc @kamicut 