### PR TITLE
Drop hashtag uniqueness

### DIFF
--- a/app/db/migrations/20221121094350_drop-hashtag-uniqueness.js
+++ b/app/db/migrations/20221121094350_drop-hashtag-uniqueness.js
@@ -1,0 +1,11 @@
+exports.up = function (knex) {
+  return knex.schema.alterTable('team', function (table) {
+    table.dropUnique('hashtag')
+  })
+}
+
+exports.down = function (knex) {
+  return knex.schema.alterTable('team', function (table) {
+    table.unique('hashtag')
+  })
+}


### PR DESCRIPTION
There is a constraint forbidding different teams to have the same hashtag. This was introduced in the early stages of OSM Teams, but it doesn't seem necessary at the moment. This contributes to #308.

This change will affect OSM Teams v1. If this works we can add the same migration file to v2.

cc @kamicut 