### PR TITLE
add vercel url to config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -19,7 +19,10 @@ module.exports = {
     HYDRA_ADMIN_HOST: process.env.HYDRA_ADMIN_HOST || 'http://localhost:4445',
   },
   publicRuntimeConfig: {
-    APP_URL: process.env.APP_URL || 'http://127.0.0.1:3000',
+    APP_URL:
+      process.env.APP_URL ||
+      process.env.NEXT_PUBLIC_VERCEL_URL ||
+      'http://127.0.0.1:3000',
     OSM_NAME: process.env.OSM_NAME || 'OSM',
   },
   eslint: {


### PR DESCRIPTION
Ideally, we should do away with `publicRuntimeConfig` and `serverRuntimeConfig` because they are deprecated. This PR allows us to use preview deploys by setting the APP_URL to the Vercel URL when deploying there.