### PR TITLE
Remove dotenv module

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,3 @@
-require('dotenv').config()
-
 const vercelUrl =
   process.env.NEXT_PUBLIC_VERCEL_URL &&
   `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "cors": "^2.8.5",
     "csurf": "^1.11.0",
     "date-fns": "^2.28.0",
-    "dotenv": "^6.2.0",
     "express": "^4.17.2",
     "express-boom": "^2.0.0",
     "express-pino-logger": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3342,11 +3342,6 @@ dot-prop@^4.2.1:
   dependencies:
     is-obj "^1.0.0"
 
-dotenv@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
-  integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
-
 drange@^1.0.2:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/drange/-/drange-1.1.1.tgz#b2aecec2aab82fcef11dbbd7b9e32b83f8f6c0b8"


### PR DESCRIPTION
Next.js handles environment files in a [very particular way](https://nextjs.org/docs/basic-features/environment-variables) and already loads the .env file. I'm removing `dotenv` module as it is not necessary and might generate conflicts in the future.

cc @kamicut @batpad 