### PR TITLE
Add maintenance mode to v1

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -35,6 +35,14 @@ app.use(boom())
 async function init () {
   await nextApp.prepare()
 
+  // On maintenance mode, render maintenance page
+  if (process.env.MAINTENANCE_MODE === 'true') {
+    app.get('/*', (req, res) => {
+      return nextApp.render(req, res, '/maintenance')
+    })
+    return app
+  }
+
   /**
    * Sub apps init
    */

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -6,6 +6,7 @@ import Layout from '../components/layout.js'
 import PageBanner from '../components/banner'
 import Button from '../components/button'
 import { ToastContainer } from 'react-toastify'
+import MaintenancePage from './maintenance'
 
 class OSMHydra extends App {
   static async getInitialProps ({ Component, ctx }) {
@@ -26,9 +27,13 @@ class OSMHydra extends App {
   }
 
   render () {
-    const { Component, pageProps, userData } = this.props
+    const { Component, pageProps, userData, router } = this.props
     let bannerContent
     let { uid, username, picture } = userData
+
+    if (router && router.pathname === '/maintenance') {
+      return <MaintenancePage />
+    }
 
     // store the userdata in localstorage if in browser
     let authed

--- a/pages/maintenance.js
+++ b/pages/maintenance.js
@@ -1,0 +1,4 @@
+
+export default function MaintenancePage () {
+  return <div>OSM Teams is under maintenance, please come back soon.</div>
+}


### PR DESCRIPTION
This adds an environment variable "MAINTENANCE_MODE" that will render a simple maintenance page on all pages and API routes.

To test, run `MAINTENANCE_MODE=true yarn dev` and access any route.

@batpad @kamicut ready for review.