### PR TITLE
Add username table

### DIFF
--- a/migrations/20221216122421_username_table.js
+++ b/migrations/20221216122421_username_table.js
@@ -1,10 +1,6 @@
-/**
- * @param { import("knex").Knex } knex
- * @returns { Promise<void> }
- */
 exports.up = async function (knex) {
   await knex.schema.createTable('usernames', (table) => {
-    table.integer('id')
+    table.integer('id').primary()
     table.text('name')
     table.text('image')
     table.datetime('updated_at').defaultTo(knex.fn.now())

--- a/migrations/20221216122421_username_table.js
+++ b/migrations/20221216122421_username_table.js
@@ -1,0 +1,20 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  await knex.schema.createTable('usernames', (table) => {
+    table.integer('id')
+    table.text('name')
+    table.text('image')
+    table.datetime('updated_at').defaultTo(knex.fn.now())
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  await knex.schema.dropTable('usernames')
+}

--- a/migrations/20221216122421_username_table.js
+++ b/migrations/20221216122421_username_table.js
@@ -7,10 +7,6 @@ exports.up = async function (knex) {
   })
 }
 
-/**
- * @param { import("knex").Knex } knex
- * @returns { Promise<void> }
- */
 exports.down = async function (knex) {
   await knex.schema.dropTable('usernames')
 }

--- a/migrations/20221216122421_username_table.js
+++ b/migrations/20221216122421_username_table.js
@@ -1,5 +1,5 @@
 exports.up = async function (knex) {
-  await knex.schema.createTable('usernames', (table) => {
+  await knex.schema.createTable('osm_users', (table) => {
     table.integer('id').primary()
     table.text('name')
     table.text('image')
@@ -8,5 +8,5 @@ exports.up = async function (knex) {
 }
 
 exports.down = async function (knex) {
-  await knex.schema.dropTable('usernames')
+  await knex.schema.dropTable('osm_users')
 }

--- a/src/components/profile-modal.js
+++ b/src/components/profile-modal.js
@@ -182,9 +182,9 @@ export default function ProfileModal({
     <article className='modal__body'>
       <div className='modal__header'>
         <div className='user__item'>
-          {user.img ? (
+          {user.image ? (
             <figure>
-              <img src={user.img} />
+              <img src={user.image} />
             </figure>
           ) : (
             <figure>

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -1,4 +1,4 @@
-import Pino from 'pino'
+const Pino = require('pino')
 
 /**
  * Create logger instance. Level is set to 'silent' when testing.
@@ -8,4 +8,4 @@ const logger = Pino({
   level: process.env.LOG_LEVEL || 'info',
 })
 
-export default logger
+module.exports = logger

--- a/src/models/team.js
+++ b/src/models/team.js
@@ -1,4 +1,5 @@
 const db = require('../lib/db')
+const logger = require('../lib/logger')
 const knexPostgis = require('knex-postgis')
 const join = require('url-join')
 const xml2js = require('xml2js')
@@ -117,7 +118,7 @@ async function resolveMemberNames(ids) {
       })
       await db('usernames').insert(usersToInsert)
     } catch (e) {
-      console.error(e)
+      logger.error(e)
       throw new Error('Could not resolve usernames from OSM')
     }
   }

--- a/tests/api/cache.test.js
+++ b/tests/api/cache.test.js
@@ -1,0 +1,27 @@
+const test = require('ava')
+const db = require('../../src/lib/db')
+const createAgent = require('../utils/create-agent')
+const { resetDb, disconnectDb } = require('../utils/db-helpers')
+
+let user1Agent
+test.before(async () => {
+  await resetDb()
+  user1Agent = await createAgent({ id: 1 })
+})
+
+test.after.always(disconnectDb)
+
+test('cache is filled when requesting team members', async (t) => {
+  let team1 = await user1Agent
+    .post('/api/teams')
+    .send({ name: 'cache team 1' })
+    .expect(200)
+
+  const team1Id = team1.body.id
+
+  // Make a request to getMembers
+  await user1Agent.get(`/api/teams/${team1Id}/members`).expect(200)
+
+  const usernames = await db('osm_users').select()
+  t.true(usernames.length > 0)
+})


### PR DESCRIPTION
This allows us to cache requests to OSM in a username table. I've added an updated_at table column so that we can run a subroutine to backfill missing usernames and also update them on a regular basis from OSM. For example, we could have a subroutine that picks the 10 least recent and request the usernames from OSM and update the database every x minutes.