### PR TITLE
Make sure user ids are integers when resolving member names

### DIFF
--- a/src/models/team.js
+++ b/src/models/team.js
@@ -66,10 +66,13 @@ const teamAttributes = [
  *
  */
 async function resolveMemberNames(ids) {
+  // TODO Quick fix, we need to do proper type validation
+  const userIds = ids.map((i) => parseInt(i))
+
   // get the display names from the database table first
-  const foundUsers = await db('osm_users').whereIn('id', ids)
+  const foundUsers = await db('osm_users').whereIn('id', userIds)
   const foundUserIds = foundUsers.map(prop('id'))
-  const notFound = difference(ids, foundUserIds)
+  const notFound = difference(userIds, foundUserIds)
 
   let usersFromOSM = []
   if (notFound.length > 0) {


### PR DESCRIPTION
Some parts of the app call the function `Team.resolveMemberNames` with an array of strings, which causes an error updating username caching. Adding a team member is failing because of this.

I added a fix to ensure user ids are integers. Ideally, we should add test coverage property types on Models.

This contributes to #298 and #355.

To test, visit a team member page and try adding a member.

@kamicut ready for review.