### PR TITLE
Fix data fetching on badge page

### DIFF
--- a/src/pages/organizations/[id]/badges/[badgeId]/index.js
+++ b/src/pages/organizations/[id]/badges/[badgeId]/index.js
@@ -60,16 +60,15 @@ export default class EditBadge extends Component {
   async loadData() {
     const { orgId, badgeId } = this.props
     try {
-      const [org, badge, { members }, { managers, owners }] = await Promise.all(
-        [
+      const [org, badge, { data: members }, { data: staff }] =
+        await Promise.all([
           getOrg(orgId),
           apiClient.get(`/organizations/${orgId}/badges/${badgeId}`),
           apiClient.get(`/organizations/${orgId}/members`),
           apiClient.get(`/organizations/${orgId}/staff`),
-        ]
-      )
+        ])
 
-      const assignablePeople = members.concat(managers).concat(owners)
+      const assignablePeople = members.concat(staff)
 
       this.setState({
         org,

--- a/src/pages/organizations/[id]/badges/add.js
+++ b/src/pages/organizations/[id]/badges/add.js
@@ -9,7 +9,7 @@ import { getRandomColor } from '../../../../lib/utils'
 import { toast } from 'react-toastify'
 import logger from '../../../../lib/logger'
 
-const URL = process.APP_URL
+const URL = process.env.APP_URL
 
 const apiClient = new APIClient()
 


### PR DESCRIPTION
Contributes to #358 by avoiding breaking the badge page. This also fix the badge creation page, which was broken.

@kamicut ready for review