### PR TITLE
Run checks on develop

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Test
 
 on:
+  push:
+    branches:
+      - 'develop'
   pull_request:
     types:
       - opened


### PR DESCRIPTION
This PR will make Github Actions run checks on every commit to develop, which will help us catch regressions when we push changes to the `develop` branch directly without opening a PR, like when updating the release version or adding quick fixes.

cc @kamicut 