### PR TITLE
Token Validation for API calls, fix #354

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -3,3 +3,4 @@ NEXTAUTH_SECRET=next-auth-cypress-secret
 DATABASE_URL=postgres://postgres:postgres@localhost:5434/osm-teams-test
 TESTING=true
 LOG_LEVEL=silent
+AUTH_URL=http://127.0.0.1:3000

--- a/next.config.js
+++ b/next.config.js
@@ -11,21 +11,14 @@ module.exports = {
       process.env.OSM_API ||
       process.env.OSM_DOMAIN ||
       'https://www.openstreetmap.org',
-    OSM_HYDRA_ID: process.env.OSM_HYDRA_ID || 'manage',
-    OSM_HYDRA_SECRET: process.env.OSM_HYDRA_SECRET || 'manage-secret',
-    OSM_CONSUMER_KEY: process.env.OSM_CONSUMER_KEY,
-    OSM_CONSUMER_SECRET: process.env.OSM_CONSUMER_SECRET,
-    HYDRA_TOKEN_HOST: process.env.HYDRA_TOKEN_HOST || 'http://localhost:4444',
-    HYDRA_TOKEN_PATH: process.env.HYDRA_TOKEN_PATH || '/oauth2/token',
-    HYDRA_AUTHZ_HOST: process.env.HYDRA_AUTHZ_HOST || 'http://localhost:4444',
-    HYDRA_AUTHZ_PATH: process.env.HYDRA_AUTHZ_PATH || '/oauth2/auth',
-    HYDRA_ADMIN_HOST: process.env.HYDRA_ADMIN_HOST || 'http://localhost:4445',
   },
   basePath: process.env.BASE_PATH || '',
   env: {
     APP_URL: process.env.APP_URL || vercelUrl || 'http://127.0.0.1:3000',
     OSM_NAME: process.env.OSM_NAME || 'OSM',
     BASE_PATH: process.env.BASE_PATH || '',
+    HYDRA_URL: process.env.HYDRA_URL || 'https://auth.mapping.team/hyauth',
+    AUTH_URL: process.env.AUTH_URL || 'https://auth.mapping.team',
   },
   eslint: {
     dirs: [

--- a/src/middlewares/base-handler.js
+++ b/src/middlewares/base-handler.js
@@ -3,8 +3,6 @@ import logger from '../lib/logger'
 import { getToken } from 'next-auth/jwt'
 import Boom from '@hapi/boom'
 
-const AUTH_URL = process.env.AUTH_URL || 'https://auth.mapping.team'
-
 /**
  * This file contains the base handler to be used in all API routes.
  *
@@ -71,7 +69,7 @@ export function createBaseHandler() {
           'Authorization scheme not supported. Only Bearer scheme is supported'
         )
       } else {
-        const result = await fetch(`${AUTH_URL}/api/introspect`, {
+        const result = await fetch(`${process.env.AUTH_URL}/api/introspect`, {
           method: 'POST',
           headers: {
             Accept: 'application/json',

--- a/src/middlewares/base-handler.js
+++ b/src/middlewares/base-handler.js
@@ -60,6 +60,9 @@ export function createBaseHandler() {
 
   // Add session to request
   baseHandler.use(async (req, res, next) => {
+    /** Handle authorization using either Bearer token auth or
+     * using the next-auth session
+     */
     if (req.headers.authorization) {
       // introspect the token
       const [type, token] = req.headers.authorization.split(' ')
@@ -86,10 +89,11 @@ export function createBaseHandler() {
           throw Boom.badRequest('Invalid token')
         }
       }
-    }
-    const token = await getToken({ req })
-    if (token) {
-      req.session = { user_id: token.userId || token.sub }
+    } else {
+      const token = await getToken({ req })
+      if (token) {
+        req.session = { user_id: token.userId || token.sub }
+      }
     }
     next()
   })

--- a/src/middlewares/can/authenticated.js
+++ b/src/middlewares/can/authenticated.js
@@ -1,0 +1,19 @@
+import Boom from '@hapi/boom'
+
+/**
+ * Authenticated
+ *
+ * To view this route you must be authenticated
+ *
+ * @returns {Promise<boolean>}
+ */
+export default async function isAuthenticated(req, res, next) {
+  const userId = req.session?.user_id
+
+  // Must be owner or manager
+  if (!userId) {
+    throw Boom.unauthorized()
+  } else {
+    next()
+  }
+}

--- a/src/pages/api/auth/[...nextauth].js
+++ b/src/pages/api/auth/[...nextauth].js
@@ -2,8 +2,6 @@ import NextAuth from 'next-auth'
 import { mergeDeepRight } from 'ramda'
 const db = require('../../../lib/db')
 
-const HYDRA_URL = process.env.HYDRA_URL || 'https://auth.mapping.team/hyauth'
-
 export const authOptions = {
   // Configure one or more authentication providers
   providers: [
@@ -11,7 +9,7 @@ export const authOptions = {
       id: 'osm-teams',
       name: 'OSM Teams',
       type: 'oauth',
-      wellKnown: `${HYDRA_URL}/.well-known/openid-configuration`,
+      wellKnown: `${process.env.HYDRA_URL}/.well-known/openid-configuration`,
       authorization: { params: { scope: 'openid offline' } },
       idToken: true,
       async profile(profile) {

--- a/src/pages/api/auth/[...nextauth].js
+++ b/src/pages/api/auth/[...nextauth].js
@@ -2,6 +2,8 @@ import NextAuth from 'next-auth'
 import { mergeDeepRight } from 'ramda'
 const db = require('../../../lib/db')
 
+const HYDRA_URL = process.env.HYDRA_URL || 'https://auth.mapping.team/hyauth'
+
 export const authOptions = {
   // Configure one or more authentication providers
   providers: [
@@ -9,8 +11,7 @@ export const authOptions = {
       id: 'osm-teams',
       name: 'OSM Teams',
       type: 'oauth',
-      wellKnown:
-        'https://auth.mapping.team/hyauth/.well-known/openid-configuration',
+      wellKnown: `${HYDRA_URL}/.well-known/openid-configuration`,
       authorization: { params: { scope: 'openid offline' } },
       idToken: true,
       async profile(profile) {

--- a/src/pages/api/introspect.js
+++ b/src/pages/api/introspect.js
@@ -1,0 +1,24 @@
+const { decode } = require('next-auth/jwt')
+/**
+ * !! This function is only used for testing
+ * purposes, it mocks the hydra access token introspection
+ */
+export default async function handler(req, res) {
+  if (req.method === 'POST') {
+    // Process a POST request
+    const { token } = req.body
+    const decodedToken = await decode({
+      token,
+      secret: process.env.NEXT_AUTH_SECRET,
+    })
+
+    const result = {
+      active: true,
+      sub: decodedToken.userId,
+    }
+
+    res.status(200).json(result)
+  } else {
+    res.status(400)
+  }
+}

--- a/src/pages/api/my/teams.js
+++ b/src/pages/api/my/teams.js
@@ -2,6 +2,7 @@ import * as Yup from 'yup'
 import Team from '../../../models/team'
 import { createBaseHandler } from '../../../middlewares/base-handler'
 import { validate } from '../../../middlewares/validation'
+import isAuthenticated from '../../../middlewares/can/authenticated'
 
 const handler = createBaseHandler()
 
@@ -26,6 +27,7 @@ const handler = createBaseHandler()
  *                   $ref: '#/components/schemas/ArrayOfTeams'
  */
 handler.get(
+  isAuthenticated,
   validate({
     query: Yup.object({
       page: Yup.number().min(0).integer(),

--- a/tests/api/team-api.test.js
+++ b/tests/api/team-api.test.js
@@ -4,9 +4,11 @@ const { resetDb, disconnectDb } = require('../utils/db-helpers')
 const createAgent = require('../utils/create-agent')
 
 let user1Agent
+let user1HttpAgent
 test.before(async () => {
   await resetDb()
   user1Agent = await createAgent({ id: 1 })
+  user1HttpAgent = await createAgent({ id: 1, http: true })
 })
 
 test.after.always(disconnectDb)
@@ -252,7 +254,13 @@ test('get my teams list', async (t) => {
       data: teams,
     },
   } = await user1Agent.get(`/api/my/teams`).expect(200)
+
   t.is(total, 2)
   t.is(teams[0].name, 'Team 1')
   t.is(teams[1].name, 'Team 2')
+
+  const httpApiResponse = await user1HttpAgent.get(`/api/my/teams`).expect(200)
+
+  // Has to be the same
+  t.deepEqual(httpApiResponse.body.data, teams)
 })

--- a/tests/utils/create-agent.js
+++ b/tests/utils/create-agent.js
@@ -1,6 +1,7 @@
+const logger = require('../../src/lib/logger')
 const getSessionToken = require('./get-session-token')
 
-async function createAgent(user) {
+async function createAgent(user, http = false) {
   const agent = require('supertest').agent('http://localhost:3000')
 
   if (user) {
@@ -8,6 +9,9 @@ async function createAgent(user) {
       user,
       process.env.NEXTAUTH_SECRET
     )
+    if (http) {
+      agent.set('Authorization', `Bearer ${encryptedToken}`)
+    }
     agent.set('Cookie', [`next-auth.session-token=${encryptedToken}`])
   }
 

--- a/tests/utils/create-agent.js
+++ b/tests/utils/create-agent.js
@@ -1,4 +1,3 @@
-const logger = require('../../src/lib/logger')
 const getSessionToken = require('./get-session-token')
 
 async function createAgent(user, http = false) {

--- a/tests/utils/get-session-token.js
+++ b/tests/utils/get-session-token.js
@@ -5,7 +5,7 @@ async function getSessionToken(userObj, secret) {
   const token = { ...userObj, userId: userObj.id }
 
   // Function logic derived from https://github.com/nextauthjs/next-auth/blob/5c1826a8d1f8d8c2d26959d12375704b0a693bfc/packages/next-auth/src/jwt/index.ts#L113-L121
-  const encryptionSecret = await await hkdf(
+  const encryptionSecret = await hkdf(
     'sha256',
     secret,
     '',


### PR DESCRIPTION
This implements:
1. token extraction from authorized API calls that have `Bearer <access_token>`
2. checks if the access token is valid by sending it to the `/introspect` route in the auth proxy (check https://github.com/developmentseed/osm-teams/commit/5470dc55bcf3ae808e5dfc22f6173ae01987b741)
3. extracts the `sub` trait from the resulting token and adds it to the session

This will allow API calls from third party applications to use access tokens to authenticate with the API.

I also added `isAuthenticated` for routes that need simply to have the session and session user ids in the `can` middleware.