### PR TITLE
Update pagination button styles

### DIFF
--- a/src/components/button.js
+++ b/src/components/button.js
@@ -41,8 +41,17 @@ const ButtonStyles = css.global`
   .button.primary {
     color: #ffffff;
     background: ${theme.colors.primaryColor};
-    border: none;
+    border: 2px solid transparent;
     box-shadow: 2px 2px #ffffff, 4px 4px ${theme.colors.primaryColor};
+  }
+  .button.secondary {
+    color: ${theme.colors.primaryColor};
+    background: ${theme.colors.primaryLite};
+    box-shadow: 2px 2px #ffffff, 4px 4px ${theme.colors.primaryColor};
+  }
+  .button.flat {
+    box-shadow: none;
+    position: relative;
   }
 
   /* Button size modifiers
@@ -145,6 +154,7 @@ export default function Button({
 }) {
   let classes = [`button`, variant, className]
   if (disabled) classes.push('disabled')
+  if (flat) classes.push('flat')
   let classNames = classes.join(' ')
   if (type === 'submit') {
     return (
@@ -162,16 +172,16 @@ export default function Button({
         <style jsx>{ButtonStyles}</style>
         <style jsx>{`
           .button {
-            box-shadow: ${flat && 'none'};
-            position: relative;
+            min-width: 1.75rem;
+            min-height: 1.75rem;
           }
           .button::after {
             content: '';
-            position: absolute;
+            position: ${useIcon && 'absolute'};
             top: 0;
             left: 0;
-            width: 100%;
-            height: 100%;
+            width: ${useIcon && '100%'};
+            height: ${useIcon && '100%'};
             mask: ${useIcon
               ? `url(${join(URL, `/static/icon-${useIcon}.svg`)})`
               : 'none'};
@@ -199,16 +209,16 @@ export default function Button({
         <style jsx>{ButtonStyles}</style>
         <style jsx>{`
           .button {
-            box-shadow: ${flat && 'none'};
-            position: relative;
+            min-width: 1.75rem;
+            min-height: 1.75rem;
           }
           .button::after {
             content: '';
-            position: absolute;
+            position: ${useIcon && 'absolute'};
             top: 0;
             left: 0;
-            width: 100%;
-            height: 100%;
+            width: ${useIcon && '100%'};
+            height: ${useIcon && '100%'};
             mask: ${useIcon
               ? `url(${join(URL, `/static/icon-${useIcon}.svg`)})`
               : 'none'};
@@ -234,18 +244,16 @@ export default function Button({
       <style jsx>{ButtonStyles}</style>
       <style jsx>{`
         .button {
-          box-shadow: ${flat && 'none'};
-          position: relative;
           min-width: 1.75rem;
           min-height: 1.75rem;
         }
         .button::after {
           content: '';
-          position: absolute;
+          position: ${useIcon && 'absolute'};
           top: 0;
           left: 0;
-          width: 100%;
-          height: 100%;
+          width: ${useIcon && '100%'};
+          height: ${useIcon && '100%'};
           mask: ${useIcon
             ? `url(${join(URL, `/static/icon-${useIcon}.svg`)})`
             : 'none'};

--- a/src/components/pagination.js
+++ b/src/components/pagination.js
@@ -75,6 +75,7 @@ function Pagination({ pagination, setPage, 'data-cy': dataCy }) {
             onClick={() => setPage(page)}
             key={`page-${page}`}
             disabled={page === '...'}
+            variant={currentPage === page ? 'primary' : 'secondary'}
             data-cy={`page-${page}-button`}
             className='small'
             flat


### PR DESCRIPTION
Minor style change to distinguish active page in pagination.

@willemarcel I also notice that pagination options are behaving strangely when there are only 2 pages. See below screenshot. Changing the `PAGE_INDEX_START` const to 0 didn't seem to help adjust this, though I see that we 0-indexed other examples of this pattern. Any ideas?
![image](https://user-images.githubusercontent.com/12634024/212388585-c8fa4e2d-ed60-4f22-a8f8-354472db905e.png)
