### PR TITLE
Add back links

### DIFF
--- a/src/components/button.js
+++ b/src/components/button.js
@@ -127,7 +127,8 @@ const ButtonStyles = css.global`
   }
 
   .button.submit {
-    background-color: ${theme.colors.primaryLite};
+    color: #fff;
+    background-color: ${theme.colors.primaryColor};
   }
 
   .button.disabled {
@@ -207,9 +208,7 @@ export default function Button({
             mask-repeat: no-repeat;
             mask-position: center;
             z-index: 2;
-            background-color: ${useIcon
-              ? theme.colors.primaryColor
-              : 'initial'};
+            background-color: ${useIcon ? theme.colors.primaryLite : 'initial'};
           }
         `}</style>
       </button>

--- a/src/components/edit-org-form.js
+++ b/src/components/edit-org-form.js
@@ -82,7 +82,7 @@ export default function EditOrgForm({
                 <option value='false'>No</option>
               </Field>
               <small className='pt1'>
-                This overrides the org teams visibility setting.
+                This overrides the organization teams visibility setting.
               </small>
             </div>
             <div className='form-control form-control__vertical'>

--- a/src/components/edit-team-form.js
+++ b/src/components/edit-team-form.js
@@ -187,7 +187,7 @@ export default function EditTeamForm({
             )}
             {extraOrgTeamFields.length > 0 ? (
               <>
-                <h2>Org Attributes</h2>
+                <h2>Organization Attributes</h2>
                 {extraOrgTeamFields}
               </>
             ) : (

--- a/src/components/profile-form.js
+++ b/src/components/profile-form.js
@@ -16,6 +16,7 @@ import { getTeam } from '../lib/teams-api'
 import Button from '../components/button'
 import { propOr, prop } from 'ramda'
 import logger from '../lib/logger'
+import Link from 'next/link'
 
 function GenderSelectField(props) {
   const [field, meta, { setValue, setTouched }] = useField(props.name)
@@ -230,6 +231,7 @@ export default class ProfileForm extends Component {
 
     return (
       <article className='inner page'>
+        <Link href={returnUrl}>← Back to Team Page</Link>
         <section>
           <h1>Edit your profile details</h1>
           <Formik
@@ -379,6 +381,7 @@ export default class ProfileForm extends Component {
                           }
                         />
                         {org.privacy_policy.consentText}
+                        <span className='form--required'>*</span>
                       </div>
                     </div>
                   ) : (
@@ -387,7 +390,7 @@ export default class ProfileForm extends Component {
                   {status && status.msg && <div>{status.msg}</div>}
                   <div
                     style={{ marginTop: '1rem' }}
-                    className='form-control form-control__vertical'
+                    className='section-actions'
                   >
                     <Button
                       type='submit'
@@ -395,6 +398,9 @@ export default class ProfileForm extends Component {
                       disabled={!consentChecked || isSubmitting}
                     >
                       {addProfileText}
+                    </Button>
+                    <Button variant='secondary' href={returnUrl}>
+                      Cancel
                     </Button>
                   </div>
                 </Form>

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -173,7 +173,7 @@ const sidebarStyles = css.global`
   }
   @media screen and (min-width: ${theme.mediaRanges.large}) {
     .page__sidebar {
-      align-items: baseline;
+      align-items: center;
       overflow: hidden;
     }
 

--- a/src/pages/organizations/[id]/badges/[badgeId]/assign/[userId].js
+++ b/src/pages/organizations/[id]/badges/[badgeId]/assign/[userId].js
@@ -8,6 +8,9 @@ import { toast } from 'react-toastify'
 import join from 'url-join'
 import Router from 'next/router'
 import logger from '../../../../../../lib/logger'
+import Link from 'next/link'
+import theme from '../../../../../../styles/theme'
+import Badge from '../../../../../../components/badge'
 
 const URL = process.env.APP_URL
 
@@ -108,10 +111,11 @@ export default class EditBadgeAssignment extends Component {
 
     return (
       <>
-        <div className='page__heading'>
-          <h1>Badge Assignment</h1>
-        </div>
+        <Link href={join(URL, `/organizations/${orgId}/badges/${badgeId}`)}>
+          ← Back to Badge
+        </Link>
         <Section>
+          <h1>Badge Assignment</h1>
           <Formik
             initialValues={{
               assignedAt:
@@ -160,12 +164,20 @@ export default class EditBadgeAssignment extends Component {
             render={({ isSubmitting, values, errors }) => {
               return (
                 <Form>
-                  <div className='page__heading'>
-                    <h2>User: {userId} (OSM id)</h2>
-                  </div>
-                  <div className='page__heading'>
-                    <h2>Badge: {badge && badge.name}</h2>
-                  </div>
+                  <dl>
+                    <dt>OSM User ID:</dt>
+                    <dd> {userId}</dd>
+                    {badge && (
+                      <>
+                        <dt>Badge:</dt>
+                        <dd style={{ color: badge.color }}>
+                          <Badge dot color={badge.color}>
+                            {badge.name}
+                          </Badge>
+                        </dd>
+                      </>
+                    )}
+                  </dl>
                   <div className='form-control form-control__vertical'>
                     <label htmlFor='assignedAt'>Assigned At (required)</label>
                     <Field
@@ -196,7 +208,6 @@ export default class EditBadgeAssignment extends Component {
                       value={badge ? 'Update' : 'Assign'}
                     />
                     <Button
-                      variant='small'
                       href={`/organizations/${orgId}`}
                       value='Go to organization view'
                     />
@@ -255,6 +266,23 @@ export default class EditBadgeAssignment extends Component {
             </div>
           </Section>
         )}
+        <style jsx>
+          {`
+            dl {
+              display: grid;
+              grid-template-columns: max-content 1fr;
+              gap: 0.25rem 1rem;
+            }
+
+            dt {
+              font-family: ${theme.typography.headingFontFamily};
+              text-transform: uppercase;
+            }
+            dd {
+              font-weight: ${theme.typography.baseFontSemiBold};
+            }
+          `}
+        </style>
       </>
     )
   }

--- a/src/pages/organizations/[id]/badges/[badgeId]/assign/[userId].js
+++ b/src/pages/organizations/[id]/badges/[badgeId]/assign/[userId].js
@@ -170,7 +170,7 @@ export default class EditBadgeAssignment extends Component {
                     {badge && (
                       <>
                         <dt>Badge:</dt>
-                        <dd style={{ color: badge.color }}>
+                        <dd>
                           <Badge dot color={badge.color}>
                             {badge.name}
                           </Badge>

--- a/src/pages/organizations/[id]/badges/[badgeId]/index.js
+++ b/src/pages/organizations/[id]/badges/[badgeId]/index.js
@@ -10,6 +10,7 @@ import theme from '../../../../../styles/theme'
 import Table from '../../../../../components/tables/table'
 import { toDateString } from '../../../../../lib/utils'
 import logger from '../../../../../lib/logger'
+import Link from 'next/link'
 
 const URL = process.env.APP_URL
 
@@ -147,12 +148,13 @@ export default class EditBadge extends Component {
 
     return (
       <article className='inner page'>
-        <div className='page__heading'>
-          <h1>{this.state.org.name}</h1>
-        </div>
+        <Link href={join(URL, `/organizations/${orgId}`)}>
+          ← Back to Organization Page
+        </Link>
         <section>
+          <h3>{this.state.org.name}</h3>
           <div className='page__heading'>
-            <h2>Edit Badge</h2>
+            <h1>Edit badge</h1>
           </div>
           <Formik
             initialValues={{ name: badge.name, color: badge.color }}

--- a/src/pages/organizations/[id]/badges/add.js
+++ b/src/pages/organizations/[id]/badges/add.js
@@ -8,6 +8,7 @@ import Router from 'next/router'
 import { getRandomColor } from '../../../../lib/utils'
 import { toast } from 'react-toastify'
 import logger from '../../../../lib/logger'
+import Link from 'next/link'
 
 const URL = process.env.APP_URL
 
@@ -83,12 +84,13 @@ export default class AddBadge extends Component {
 
     return (
       <article className='inner page'>
+        <Link href={join(URL, `/organizations/${orgId}`)}>
+          ← Back to Organization Page
+        </Link>
         <section>
+          <h3>{this.state.org.name}</h3>
           <div className='page__heading'>
-            <h1>{this.state.org.name}</h1>
-          </div>
-          <div className='page__heading'>
-            <h2>New badge</h2>
+            <h1>New badge</h1>
           </div>
 
           <Formik

--- a/src/pages/organizations/[id]/badges/assign/[userId].js
+++ b/src/pages/organizations/[id]/badges/assign/[userId].js
@@ -8,6 +8,8 @@ import { toast } from 'react-toastify'
 import join from 'url-join'
 import Router from 'next/router'
 import logger from '../../../../../lib/logger'
+import Link from 'next/link'
+import theme from '../../../../../styles/theme'
 
 const URL = process.env.APP_URL
 
@@ -96,9 +98,9 @@ export default class NewBadgeAssignment extends Component {
 
     return (
       <>
-        <div className='page__heading'>
-          <h1>Badge Assignment</h1>
-        </div>
+        <Link href={join(URL, `/organizations/${orgId}`)}>
+          ← Back to Organization Page
+        </Link>
         <Section>
           <Formik
             initialValues={{
@@ -152,8 +154,12 @@ export default class NewBadgeAssignment extends Component {
               return (
                 <Form>
                   <div className='page__heading'>
-                    <h2>User: {userId} (OSM id)</h2>
+                    <h1>Badge Assignment</h1>
                   </div>
+                  <dl>
+                    <dt>OSM User ID:</dt>
+                    <dd>{userId}</dd>
+                  </dl>
 
                   <div className='form-control form-control__vertical'>
                     <label htmlFor='badgeId'>Badge:</label>
@@ -199,7 +205,6 @@ export default class NewBadgeAssignment extends Component {
                       value='Assign'
                     />
                     <Button
-                      variant='small'
                       href={`/organizations/${orgId}`}
                       value='Go to organization view'
                     />
@@ -209,6 +214,24 @@ export default class NewBadgeAssignment extends Component {
             }}
           />
         </Section>
+        <style jsx>
+          {`
+            dl {
+              display: grid;
+              grid-template-columns: max-content 1fr;
+              gap: 0.25rem 1rem;
+            }
+
+            dt {
+              font-family: ${theme.typography.headingFontFamily};
+              text-transform: uppercase;
+            }
+
+            .team__table {
+              grid-column: 1 / span 12;
+            }
+          `}
+        </style>
       </>
     )
   }

--- a/src/pages/organizations/[id]/edit-privacy-policy.js
+++ b/src/pages/organizations/[id]/edit-privacy-policy.js
@@ -5,6 +5,7 @@ import Router from 'next/router'
 import { getOrg, updateOrgPrivacyPolicy } from '../../../lib/org-api'
 import PrivacyPolicyForm from '../../../components/privacy-policy-form'
 import logger from '../../../lib/logger'
+import Link from 'next/link'
 
 const APP_URL = process.env.APP_URL
 
@@ -67,6 +68,9 @@ export default class OrgPrivacyPolicy extends Component {
 
     return (
       <article className='inner page'>
+        <Link href={`/organizations/${orgId}/edit`}>
+          ← Back to Edit Organization
+        </Link>
         <section>
           <div className='page__heading'>
             <h1>Edit Privacy Policy</h1>

--- a/src/pages/organizations/[id]/edit-profiles.js
+++ b/src/pages/organizations/[id]/edit-profiles.js
@@ -13,6 +13,7 @@ import {
 } from '../../../lib/profiles-api'
 import theme from '../../../styles/theme'
 import logger from '../../../lib/logger'
+import Link from 'next/link'
 
 export default class OrgEditProfile extends Component {
   static async getInitialProps({ query }) {
@@ -158,6 +159,9 @@ export default class OrgEditProfile extends Component {
 
     return (
       <article className='inner page'>
+        <Link href={`/organizations/${orgId}/edit`}>
+          ← Back to Edit Organization
+        </Link>
         <section>
           <h2>Current Attributes</h2>
           <p>

--- a/src/pages/organizations/[id]/edit-team-profiles.js
+++ b/src/pages/organizations/[id]/edit-team-profiles.js
@@ -13,6 +13,7 @@ import {
 } from '../../../lib/profiles-api'
 import theme from '../../../styles/theme'
 import logger from '../../../lib/logger'
+import Link from 'next/link'
 
 export default class OrgEditTeamProfile extends Component {
   static async getInitialProps({ query }) {
@@ -158,11 +159,14 @@ export default class OrgEditTeamProfile extends Component {
 
     return (
       <article className='inner page'>
+        <Link href={`/organizations/${orgId}/edit`}>
+          ← Back to Edit Organization
+        </Link>
         <section>
           <h2>Current Attributes</h2>
           <p>
             Teams of your organization will be able to add these attributes to
-            their profile.
+            their team details.
           </p>
           {teamAttributes && isEmpty(teamAttributes) ? (
             "You haven't added any attributes yet!"
@@ -191,7 +195,9 @@ export default class OrgEditTeamProfile extends Component {
           {this.state.isAdding ? (
             <>
               <h2>Add an attribute</h2>
-              <p>Add an attribute to your org member&apos;s profile</p>
+              <p>
+                Add an attribute to your organization&apos;s teams&apos; details
+              </p>
               <ProfileAttributeForm
                 formType='org'
                 onSubmit={async (attributes) => {

--- a/src/pages/organizations/[id]/edit.js
+++ b/src/pages/organizations/[id]/edit.js
@@ -7,6 +7,7 @@ import EditOrgForm from '../../../components/edit-org-form'
 import Button from '../../../components/button'
 import theme from '../../../styles/theme'
 import logger from '../../../lib/logger'
+import Link from 'next/link'
 
 const APP_URL = process.env.APP_URL
 
@@ -110,7 +111,7 @@ export default class OrgEdit extends Component {
       if (error.status >= 400 && error.status < 500) {
         return (
           <article className='inner'>
-            <h1>Org not found</h1>
+            <h1>Organization not found</h1>
           </article>
         )
       } else if (error.status >= 500) {
@@ -126,9 +127,12 @@ export default class OrgEdit extends Component {
 
     return (
       <article className='inner page'>
+        <Link href={join(APP_URL, `/organizations/${org.id}`)}>
+          ← Back to Organization
+        </Link>
         <section>
           <div className='page__heading'>
-            <h1>Edit Org</h1>
+            <h1>Edit Organization</h1>
           </div>
           <EditOrgForm
             initialValues={pick(
@@ -151,7 +155,7 @@ export default class OrgEdit extends Component {
         </section>
         <section>
           <div className='page__heading'>
-            <h2>Org Attributes</h2>
+            <h2>Organization Attributes</h2>
           </div>
           <div>
             <span style={{ marginRight: '1rem' }}>
@@ -181,8 +185,8 @@ export default class OrgEdit extends Component {
         <section className='danger-zone'>
           <h2>Danger Zone 🎸</h2>
           <p>
-            Delete this org, org information and all memberships associated to
-            this team
+            Delete this organization, organization information and all
+            memberships associated with this organization
           </p>
           {this.renderDeleter()}
         </section>

--- a/src/pages/organizations/[id]/index.js
+++ b/src/pages/organizations/[id]/index.js
@@ -234,7 +234,7 @@ class Organization extends Component {
       } else if (org.error.status === 404) {
         return (
           <article className='inner page'>
-            <h1>Org not found</h1>
+            <h1>Organization not found</h1>
           </article>
         )
       }
@@ -262,7 +262,7 @@ class Organization extends Component {
       } else if (error.status === 404) {
         return (
           <article className='inner page'>
-            <h1>Org not found</h1>
+            <h1>Organization not found</h1>
           </article>
         )
       } else {
@@ -328,7 +328,7 @@ class Organization extends Component {
         <div className='team__details'>
           <Section>
             <div className='section-actions'>
-              <SectionHeader>Org Details</SectionHeader>
+              <SectionHeader>Organization Details</SectionHeader>
               {isOwner ? (
                 <Button href={`/organizations/${org.data.id}/edit`}>
                   Edit

--- a/src/pages/teams/[id]/edit-profiles.js
+++ b/src/pages/teams/[id]/edit-profiles.js
@@ -13,6 +13,7 @@ import {
 } from '../../../lib/profiles-api'
 import theme from '../../../styles/theme'
 import logger from '../../../lib/logger'
+import Link from 'next/link'
 
 export default class TeamEditProfile extends Component {
   static async getInitialProps({ query }) {
@@ -158,6 +159,7 @@ export default class TeamEditProfile extends Component {
 
     return (
       <article className='inner page'>
+        <Link href={`/teams/${teamId}/edit`}>← Back to Edit Team</Link>
         <section>
           <h2>Current Attributes</h2>
           <p>

--- a/src/pages/teams/[id]/edit.js
+++ b/src/pages/teams/[id]/edit.js
@@ -12,6 +12,7 @@ import {
   getTeamProfile,
 } from '../../../lib/profiles-api'
 import logger from '../../../lib/logger'
+import Link from 'next/link'
 
 const APP_URL = process.env.APP_URL
 export default class TeamEdit extends Component {
@@ -141,6 +142,9 @@ export default class TeamEdit extends Component {
 
     return (
       <article className='inner page'>
+        <Link href={join(APP_URL, `/teams/${team.id}`)}>
+          ← Back to Team Page
+        </Link>
         <section>
           <div className='page__heading'>
             <h1>Edit Team</h1>

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -33,6 +33,7 @@ let typography = {
   baseFontFamily: "'Work Sans', sans-serif",
   baseFontStyle: 'normal',
   baseFontRegular: 400,
+  baseFontSemiBold: 600,
   baseFontBold: 700,
   baseFontWeight: 400,
   baseFontSize: '1rem',


### PR DESCRIPTION
This PR:
- Adds "Back Links" to previous/parent screens for Edit Org, Edit Team, Add, Edit & Assign Badges.
- Aligns the Badge screens with other updated interfaces (section layout, heading order, etc)
- Updates badge page styles
- Replaces the use of abbreviated "org" with "organization"

![image](https://user-images.githubusercontent.com/12634024/213330345-d79a3473-f5d5-4987-86d4-343d02c16bf5.png)

![image](https://user-images.githubusercontent.com/12634024/213330471-bd963fc9-1b7b-4a48-a9d6-98eb5e240703.png)

![image](https://user-images.githubusercontent.com/12634024/213330730-efcdf700-5710-4c7a-81cb-e2de41ebb6b5.png)

