### PR TITLE
create code guards when org or user are undefined

### DIFF
--- a/src/middlewares/can/create-org-team.js
+++ b/src/middlewares/can/create-org-team.js
@@ -16,6 +16,10 @@ export default async function canCreateOrgTeam(req, res, next) {
   const { orgId } = req.query
   const userId = req.session?.user_id
 
+  if (!userId || !orgId) {
+    throw Boom.badRequest('could not identify organization or user')
+  }
+
   // Must be owner or manager
   if (!(await isOwner(orgId, userId)) && !(await isManager(orgId, userId))) {
     throw Boom.unauthorized()

--- a/src/middlewares/can/view-org-members.js
+++ b/src/middlewares/can/view-org-members.js
@@ -12,10 +12,14 @@ export default async function canViewOrgMembers(req, res, next) {
   const { orgId } = req.query
   const userId = req.session?.user_id
 
+  if (!orgId) {
+    throw Boom.badRequest('organization id not provided')
+  }
+
   if (await isPublic(orgId)) {
     // Can view if org is public
     return next()
-  } else if (await isMemberOrStaff(orgId, userId)) {
+  } else if (userId && (await isMemberOrStaff(orgId, userId))) {
     // Can view if is member or staff
     return next()
   } else {

--- a/src/middlewares/can/view-org-teams.js
+++ b/src/middlewares/can/view-org-teams.js
@@ -11,20 +11,32 @@ import Organization from '../../models/organization'
  */
 export default async function canViewOrgTeams(req, res, next) {
   const { orgId } = req.query
+
+  if (!orgId) {
+    throw Boom.badRequest('organization id not provided')
+  }
+
+  let org = await Organization.get(orgId)
+
+  if (org?.privacy === 'public') {
+    req.org = { ...org }
+    return next()
+  }
+
   const userId = req.session?.user_id
 
-  let [org, isMember, isManager, isOwner] = await Promise.all([
-    Organization.get(orgId),
-    Organization.isMember(orgId, userId),
-    Organization.isManager(orgId, userId),
-    Organization.isOwner(orgId, userId),
-  ])
-
-  if (org?.privacy === 'public' || isMember || isManager || isOwner) {
-    // Add org and permission flags to request
-    req.org = { ...org, isMember, isManager, isOwner }
-    return next()
-  } else {
-    throw Boom.unauthorized()
+  if (userId) {
+    let [isMember, isManager, isOwner] = await Promise.all([
+      Organization.isMember(orgId, userId),
+      Organization.isManager(orgId, userId),
+      Organization.isOwner(orgId, userId),
+    ])
+    if (isMember || isManager || isOwner) {
+      // Add org and permission flags to request
+      req.org = { ...org, isMember, isManager, isOwner }
+      return next()
+    }
   }
+
+  throw Boom.unauthorized()
 }


### PR DESCRIPTION
We should ideally merge this before the release. This fixes a bug when userId or orgId are not defined in the `can` checks (i.e. unauthenticated requests to the API)