### PR TITLE
Alternative chakra button navlink component

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -1,49 +1,25 @@
-import { withRouter } from 'next/router'
-import Link from 'next/link'
-import React, { Children } from 'react'
-import parse from 'url-parse'
+import { Link as ChakraLink } from '@chakra-ui/react'
+import { Link as NextLink } from 'next/link'
+import { useRouter } from 'next/router'
+import React from 'react'
 
-const NavLink = withRouter(({ children, href, passHref, legacyBehavior }) => {
-  return (
-    <ActiveLink
-      href={href}
-      passHref={passHref}
-      legacyBehavior={legacyBehavior}
-      activeClassName='active'
-    >
-      {children}
-    </ActiveLink>
-  )
-})
+function NavLink({ href, activeProps, children, ...props }) {
+  const router = useRouter()
+  const isActive = router.pathname === href
 
-const ActiveLink = withRouter(({ router, children, ...props }) => {
-  const { href, as, passHref, legacyBehavior } = props
-  const hrefPathname = parse(href).pathname
-  const routerPathname = parse(router.asPath).pathname
-
-  const child = Children.only(children)
-
-  let className = child.props.className || null
-  if (routerPathname === hrefPathname && props.activeClassName) {
-    className = `${className !== null ? className : ''} ${
-      props.activeClassName
-    }`.trim()
+  if (isActive) {
+    return (
+      <ChakraLink as={NextLink} href={href} {...props} {...activeProps}>
+        {children}
+      </ChakraLink>
+    )
   }
 
-  delete props.activeClassName
-
   return (
-    <Link
-      {...props}
-      href={href}
-      passHref={passHref}
-      as={as}
-      legacyBehavior={legacyBehavior}
-      className={className}
-    >
-      {React.cloneElement(child, { className })}
-    </Link>
+    <ChakraLink as={NextLink} href={href} {...props}>
+      {children}
+    </ChakraLink>
   )
-})
+}
 
 export default NavLink

--- a/src/components/page-header.js
+++ b/src/components/page-header.js
@@ -36,9 +36,9 @@ export default function PageHeader() {
   const isAuthenticated = status === 'authenticated'
 
   return (
-    <Box bg='brand.500' as='header' borderBottom={'2px'} borderColor='base.600'>
+    <Box bg='white' as='header' borderBottom={'2px'} borderColor='base.600'>
       <Container
-        color='white'
+        color='brand.600'
         px={4}
         maxW='container.xl'
         position='relative'
@@ -59,49 +59,51 @@ export default function PageHeader() {
             onClick={isOpen ? onClose : onOpen}
           />
           <HStack spacing={8} alignItems={'center'}>
-            <Box>
-              <NavLink href='/' passHref legacyBehavior>
-                <Heading
-                  color='white'
-                  fontFamily='mono'
-                  size='md'
-                  as='a'
-                  _hover={{ textDecoration: 'none' }}
-                >
-                  osm_teams
-                </Heading>
-              </NavLink>
-            </Box>
+            <NavLink
+              href='/'
+              color='brand.600'
+              fontFamily='mono'
+              _hover={{ textDecoration: 'none' }}
+            >
+              osm_teams
+            </NavLink>
             <HStack
               as={'nav'}
               spacing={8}
               display={{ base: 'none', md: 'flex' }}
             >
               {Links.map((link) => (
-                <NavLink href={link.url} passHref key={link.url} legacyBehavior>
-                  <Button
-                    as='a'
-                    variant='outline'
-                    color='white'
-                    textTransform={'lowercase'}
-                    _hover={{ background: 'brand.600', textDecoration: 'none' }}
-                  >
-                    {link.name}
-                  </Button>
-                </NavLink>
+                <Button
+                  href={link.url}
+                  key={link.url}
+                  as={NavLink}
+                  size='md'
+                  variant='outline'
+                  activeProps={{
+                    background: 'brand.500 !important',
+                    color: 'white !important',
+                    border:
+                      '1px solid var(--chakra-colors-brand-500) !important',
+                  }}
+                >
+                  {link.name}
+                </Button>
               ))}
               {isAuthenticated && (
-                <NavLink href={'/profile'} passHref legacyBehavior>
-                  <Button
-                    as='a'
-                    variant='outline'
-                    color='white'
-                    textTransform={'lowercase'}
-                    _hover={{ background: 'brand.600', textDecoration: 'none' }}
-                  >
-                    Dashboard
-                  </Button>
-                </NavLink>
+                <Button
+                  href={'/profile'}
+                  as={NavLink}
+                  size='md'
+                  variant='outline'
+                  activeProps={{
+                    background: 'brand.500 !important',
+                    color: 'white !important',
+                    border:
+                      '1px solid var(--chakra-colors-brand-500) !important',
+                  }}
+                >
+                  Dashboard
+                </Button>
               )}
             </HStack>
           </HStack>
@@ -112,7 +114,7 @@ export default function PageHeader() {
                   <MenuButton
                     as={Button}
                     variant='outline'
-                    color='white'
+                    color='brand.600'
                     textTransform={'lowercase'}
                     _hover={{ background: 'brand.600', textDecoration: 'none' }}
                     size={'sm'}
@@ -144,7 +146,11 @@ export default function PageHeader() {
                     border={'2px'}
                     borderColor='base.600'
                   >
-                    <Avatar size={'sm'} src={session.user.image} />
+                    <Avatar
+                      size={'sm'}
+                      src={session.user.image}
+                      name={session.user.name}
+                    />
                   </MenuButton>
                   <MenuList
                     bg='brand.600'
@@ -199,17 +205,7 @@ export default function PageHeader() {
             <DrawerContent bg='brand.500' color='white' zIndex='3000'>
               <DrawerCloseButton />
               <DrawerBody py={4}>
-                <NavLink href='/' passHref legacyBehavior>
-                  <Heading
-                    color='white'
-                    fontFamily='mono'
-                    size='md'
-                    as='a'
-                    _hover={{ textDecoration: 'none' }}
-                  >
-                    osm_teams
-                  </Heading>
-                </NavLink>
+                <NavLink href='/'>osm_teams</NavLink>
                 <List spacing='8' mt={16}>
                   {Links.map((link) => (
                     <ListItem key={link.url}>


### PR DESCRIPTION
This branch uses an alternative approach to render navlinks as semantically correct Chakra buttons with an active style.

![image](https://user-images.githubusercontent.com/12634024/223182533-37f71917-cb87-41ec-925e-42a826d1fcfb.png)

Currently it seems that the links are reloading the page each time, rather than routing internally for the SPA, so I don't think this is correct yet.