### PR TITLE
move badge client code to separate file

### DIFF
--- a/src/lib/badges-api.js
+++ b/src/lib/badges-api.js
@@ -1,0 +1,36 @@
+const { default: ApiClient } = require('./api-client')
+const logger = require('./logger')
+
+const apiClient = new ApiClient()
+
+/**
+ * Get badges from an organization
+ *
+ * @param {int} orgId - id of the organization
+ * @returns {array[badges]}
+ */
+export async function getOrgBadges(orgId) {
+  try {
+    const badges = await apiClient.get(`/organizations/${orgId}/badges`)
+    return badges
+  } catch (e) {
+    if (e.statusCode === 401) {
+      logger.error("User doesn't have access to organization badges.")
+    } else {
+      logger.error(e)
+    }
+  }
+}
+
+export async function getUserBadges(userId) {
+  try {
+    const badges = await apiClient.get(`/user/${userId}/badges`)
+    return badges
+  } catch (e) {
+    if (e.statusCode === 401) {
+      logger.error("User doesn't have access to organization badges.")
+    } else {
+      logger.error(e)
+    }
+  }
+}

--- a/src/pages/teams/[id]/index.js
+++ b/src/pages/teams/[id]/index.js
@@ -33,6 +33,7 @@ import { getOrgStaff } from '../../../lib/org-api'
 import { toast } from 'react-toastify'
 import logger from '../../../lib/logger'
 import MembersTable from './members-table'
+import { getOrgBadges } from '../../../lib/badges-api'
 
 const APP_URL = process.env.APP_URL
 const Map = dynamic(() => import('../../../components/team-map'), {
@@ -101,18 +102,21 @@ class Team extends Component {
       let team = await getTeam(id)
       let teamMembers = { moderators: [], members: [] }
       let teamProfile = []
+      let orgBadges = []
       teamMembers = await getTeamMembers(id)
       teamProfile = await getTeamProfile(id)
 
       let orgOwners = []
       if (team.org) {
         orgOwners = (await getOrgStaff(team.org.organization_id)).owners
+        orgBadges = await getOrgBadges(team.org.organization_id)
       }
       this.setState({
         team,
         teamProfile,
         teamMembers,
         orgOwners,
+        orgBadges,
         loading: false,
       })
     } catch (e) {
@@ -261,6 +265,8 @@ class Team extends Component {
     const userId = this.state.session?.user_id
     const members = map(prop('id'), teamMembers.members)
     const moderators = map(prop('osm_id'), teamMembers.moderators)
+
+    logger.info(this.state)
 
     // TODO: moderators is an array of ints while members are an array of strings. fix this.
     const isUserModerator =


### PR DESCRIPTION
- [x] Create new method for getTeamMembers that includes badges code optionally
- [ ] The fields parameter will allow us to select the extended “badge” field to be propagated down to the table
- [ ] Add badges to the model when we see team members to see a team member’s individual badges (when this team is an org team)
- [ ] Make sure permissions are correct for new method for teams members
- [ ] Create a column called “badge” in the table view that can display the badges