### PR TITLE
Add text grid for Team Details

### DIFF
--- a/src/pages/teams/[id]/index.js
+++ b/src/pages/teams/[id]/index.js
@@ -11,6 +11,7 @@ import {
   Text,
   Flex,
   Stack,
+  SimpleGrid,
 } from '@chakra-ui/react'
 
 import AddMemberForm from '../../../components/add-member-form'
@@ -281,14 +282,6 @@ class Team extends Component {
             <Flex direction='column' gap={2}>
               <Heading color='white'>{team.name}</Heading>
               <Flex gap={[4, 8]}>
-                {team.hashtag && (
-                  <Stack as='dl' spacing={1}>
-                    <Text as='dt' variant='overline'>
-                      Hashtag
-                    </Text>
-                    <Text as='dd'>{team.hashtag}</Text>
-                  </Stack>
-                )}
                 {team.org && (
                   <Stack as='dl' spacing={1}>
                     <Text as='dt' variant='overline'>
@@ -304,31 +297,13 @@ class Team extends Component {
                     </Text>
                   </Stack>
                 )}
-                {teamProfile &&
-                  teamProfile.map((key) => {
-                    if (key.value) {
-                      return (
-                        <Stack as='dl' spacing={1} key={key}>
-                          <Text
-                            fontFamily='mono'
-                            as='dt'
-                            fontSize='sm'
-                            textTransform={'uppercase'}
-                          >
-                            {key.name}
-                          </Text>
-                          <Text as='dd'>{key.value}</Text>
-                        </Stack>
-                      )
-                    }
-                  })}
-                {team.editing_policy && (
-                  <a
-                    href={team.editing_policy}
-                    className='team__editing_policy'
-                  >
-                    Organized editing policy
-                  </a>
+                {team.hashtag && (
+                  <Stack as='dl' spacing={1}>
+                    <Text as='dt' variant='overline'>
+                      Hashtag
+                    </Text>
+                    <Text as='dd'>{team.hashtag}</Text>
+                  </Stack>
                 )}
               </Flex>
             </Flex>
@@ -368,6 +343,56 @@ class Team extends Component {
             <Box as='section' layerStyle='shadowed'>
               <Heading variant='sectionHead'>Team Description</Heading>
               <Text>{team.bio}</Text>
+            </Box>
+          )}
+          {teamProfile.length > 0 && (
+            <Box as='section' layerStyle='shadowed'>
+              <Heading variant='sectionHead'>Team Details</Heading>
+              <SimpleGrid columns={[2, null, 3]} spacing={2}>
+                {team.org && (
+                  <Stack as='dl' spacing={0}>
+                    <Text as='dt' variant='overline'>
+                      Organization
+                    </Text>
+                    <Text as='dd'>
+                      <Link
+                        href={`/organizations/${team.org.organization_id}`}
+                        style={{ textDecoration: 'underline' }}
+                      >
+                        {team.org.name}
+                      </Link>
+                    </Text>
+                  </Stack>
+                )}
+                {team.hashtag && (
+                  <Stack as='dl' spacing={0}>
+                    <Text as='dt' variant='overline'>
+                      Hashtag
+                    </Text>
+                    <Text as='dd'>{team.hashtag}</Text>
+                  </Stack>
+                )}
+                {team.editing_policy && (
+                  <a
+                    href={team.editing_policy}
+                    className='team__editing_policy'
+                  >
+                    Organized editing policy
+                  </a>
+                )}
+                {teamProfile.map((key) => {
+                  if (key.value) {
+                    return (
+                      <Stack as='dl' spacing={0} key={key}>
+                        <Text variant={'overline'} as='dt'>
+                          {key.name}
+                        </Text>
+                        <Text as='dd'>{key.value}</Text>
+                      </Stack>
+                    )
+                  }
+                })}
+              </SimpleGrid>
             </Box>
           )}
 


### PR DESCRIPTION
Change render of team details for teams, catching instances where multiple team details exist

New view:
![image](https://user-images.githubusercontent.com/12634024/224789352-1a1af531-76a8-4a86-b397-77176c186dc2.png)

Old view:
![image](https://user-images.githubusercontent.com/12634024/224791203-c78697b9-8395-4f7b-bd06-6ba0003a5e08.png)
