### PR TITLE
Use correct input type for edit team attributes

### DIFF
--- a/src/components/edit-team-form.js
+++ b/src/components/edit-team-form.js
@@ -83,13 +83,13 @@ export default function EditTeamForm({
         }
         if (orgTeamTags.length > 0) {
           extraOrgTeamFields = orgTeamTags.map(
-            ({ id, name, required, description }) => {
+            ({ id, name, key_type, required, description }) => {
               return (
                 <FormControl isRequired={required} key={`extra-tag-${id}`}>
                   <FormLabel htmlFor={`extra-tag-${id}`}>{name}</FormLabel>
                   <Field
                     as={Input}
-                    type='text'
+                    type={key_type}
                     name={`tags.key-${id}`}
                     id={`extra-tag-${id}`}
                     required={required}
@@ -106,13 +106,13 @@ export default function EditTeamForm({
 
         if (teamTags.length > 0) {
           extraTeamFields = teamTags.map(
-            ({ id, name, required, description }) => {
+            ({ id, name, key_type, required, description }) => {
               return (
                 <FormControl isRequired={required} key={`extra-tag-${id}`}>
                   <FormLabel htmlFor={`extra-tag-${id}`}>{name}</FormLabel>
                   <Field
                     as={Input}
-                    type='text'
+                    type={key_type}
                     name={`tags.key-${id}`}
                     id={`extra-tag-${id}`}
                     required={required}
@@ -130,7 +130,7 @@ export default function EditTeamForm({
         return (
           <Form>
             <VStack alignItems={'flex-start'}>
-              <Heading variant='sectionHead'>Details</Heading>
+              <Heading variant='sectionHead'>Team Details</Heading>
               <FormControl isRequired isInvalid={errors.name}>
                 <FormLabel htmlFor='name'>Name</FormLabel>
                 <Field
@@ -223,7 +223,7 @@ export default function EditTeamForm({
               )}
               {extraOrgTeamFields.length > 0 ? (
                 <>
-                  <Heading as='h3' size='sm'>
+                  <Heading as='h3' size='sm' variant='sectionHead'>
                     Organization Attributes
                   </Heading>
                   {extraOrgTeamFields}
@@ -233,7 +233,7 @@ export default function EditTeamForm({
               )}
               {extraTeamFields.length > 0 ? (
                 <>
-                  <Heading as='h3' size='sm'>
+                  <Heading as='h3' size='sm' variant='sectionHead'>
                     Other Team Attributes
                   </Heading>
                   {extraTeamFields}


### PR DESCRIPTION
Missed during chakra conversion; uses correct input type when mapping org team attributes and extra team attributes, rather than making all inputs for org attributes "text" input type.

This PR:
![image](https://user-images.githubusercontent.com/12634024/224876403-edc5af6c-312e-4f00-b627-6d3e34536dc5.png)

Develop:
![image](https://user-images.githubusercontent.com/12634024/224876427-46febf71-f521-4c31-b0e2-4b621bed350d.png)
