### PR TITLE
Enhance profile and team edit forms

### DIFF
--- a/src/components/edit-team-form.js
+++ b/src/components/edit-team-form.js
@@ -13,6 +13,8 @@ import {
   Select,
   Checkbox,
   VStack,
+  Flex,
+  Text,
 } from '@chakra-ui/react'
 import dynamic from 'next/dynamic'
 import { uniqBy, prop } from 'ramda'
@@ -130,7 +132,7 @@ export default function EditTeamForm({
 
         return (
           <Form>
-            <VStack alignItems={'flex-start'}>
+            <VStack alignItems={'flex-start'} spacing={4}>
               <Heading variant='sectionHead'>Team Details</Heading>
               <FormControl isRequired isInvalid={errors.name}>
                 <FormLabel htmlFor='name'>Name</FormLabel>
@@ -223,12 +225,23 @@ export default function EditTeamForm({
                 </FormControl>
               )}
               {extraOrgTeamFields.length > 0 ? (
-                <>
+                <Flex
+                  flexDir='column'
+                  alignItems='flex-start'
+                  border={'1px'}
+                  borderRadius='base'
+                  p={8}
+                  borderColor='brand.50'
+                >
                   <Heading as='h3' size='sm' variant='sectionHead'>
                     {team.org?.name} Details
                   </Heading>
+                  <Text fontSize='sm' pb={4}>
+                    Organization {team.org?.name} requests the following
+                    additional details
+                  </Text>
                   {extraOrgTeamFields}
-                </>
+                </Flex>
               ) : (
                 ''
               )}

--- a/src/components/edit-team-form.js
+++ b/src/components/edit-team-form.js
@@ -83,13 +83,13 @@ export default function EditTeamForm({
         }
         if (orgTeamTags.length > 0) {
           extraOrgTeamFields = orgTeamTags.map(
-            ({ id, name, required, description }) => {
+            ({ id, name, key_type, required, description }) => {
               return (
                 <FormControl isRequired={required} key={`extra-tag-${id}`}>
                   <FormLabel htmlFor={`extra-tag-${id}`}>{name}</FormLabel>
                   <Field
                     as={Input}
-                    type='text'
+                    type={key_type}
                     name={`tags.key-${id}`}
                     id={`extra-tag-${id}`}
                     required={required}
@@ -106,13 +106,13 @@ export default function EditTeamForm({
 
         if (teamTags.length > 0) {
           extraTeamFields = teamTags.map(
-            ({ id, name, required, description }) => {
+            ({ id, name, key_type, required, description }) => {
               return (
                 <FormControl isRequired={required} key={`extra-tag-${id}`}>
                   <FormLabel htmlFor={`extra-tag-${id}`}>{name}</FormLabel>
                   <Field
                     as={Input}
-                    type='text'
+                    type={key_type}
                     name={`tags.key-${id}`}
                     id={`extra-tag-${id}`}
                     required={required}
@@ -130,7 +130,7 @@ export default function EditTeamForm({
         return (
           <Form>
             <VStack alignItems={'flex-start'}>
-              <Heading variant='sectionHead'>Details</Heading>
+              <Heading variant='sectionHead'>Team Details</Heading>
               <FormControl isRequired isInvalid={errors.name}>
                 <FormLabel htmlFor='name'>Name</FormLabel>
                 <Field
@@ -223,7 +223,7 @@ export default function EditTeamForm({
               )}
               {extraOrgTeamFields.length > 0 ? (
                 <>
-                  <Heading as='h3' size='sm'>
+                  <Heading as='h3' size='sm' variant='sectionHead'>
                     Organization Attributes
                   </Heading>
                   {extraOrgTeamFields}
@@ -233,7 +233,7 @@ export default function EditTeamForm({
               )}
               {extraTeamFields.length > 0 ? (
                 <>
-                  <Heading as='h3' size='sm'>
+                  <Heading as='h3' size='sm' variant='sectionHead'>
                     Other Team Attributes
                   </Heading>
                   {extraTeamFields}

--- a/src/components/edit-team-form.js
+++ b/src/components/edit-team-form.js
@@ -44,6 +44,7 @@ export default function EditTeamForm({
   initialValues,
   onSubmit,
   staff,
+  team,
   isCreateForm,
   orgTeamTags = [],
   teamTags = [],
@@ -224,7 +225,7 @@ export default function EditTeamForm({
               {extraOrgTeamFields.length > 0 ? (
                 <>
                   <Heading as='h3' size='sm' variant='sectionHead'>
-                    Organization Attributes
+                    {team.org?.name} Details
                   </Heading>
                   {extraOrgTeamFields}
                 </>

--- a/src/components/privacy-policy-form.js
+++ b/src/components/privacy-policy-form.js
@@ -44,16 +44,15 @@ export default function PrivacyPolicyForm({ initialValues, onSubmit }) {
       }) => {
         return (
           <VStack as={Form} alignItems='flex-start'>
-            <FormControl>
-              <FormLabel isRequired isInvalid={errors.body}>
-                Body
-              </FormLabel>
+            <FormControl isRequired isInvalid={errors.body}>
+              <FormLabel>Body</FormLabel>
               <Field
                 cols={40}
                 rows={6}
                 as={Textarea}
                 name='body'
                 id='body'
+                placeholder='Privacy policy text body'
                 value={values.body}
                 required
                 className={errors.body ? 'form-error' : ''}
@@ -68,6 +67,7 @@ export default function PrivacyPolicyForm({ initialValues, onSubmit }) {
                 as={Textarea}
                 name='consentText'
                 id='consentText'
+                placeholder='Consent text body'
                 value={values.consentText}
                 required
                 className={errors.consentText ? 'form-error' : ''}

--- a/src/components/profile-attribute-form.js
+++ b/src/components/profile-attribute-form.js
@@ -27,7 +27,7 @@ const defaultValues = {
   description: '',
   visibility: 'team',
   required: [],
-  key_type: 'text',
+  key_type: '',
 }
 
 export default function ProfileAttributeForm({
@@ -76,10 +76,8 @@ export default function ProfileAttributeForm({
 
         return (
           <VStack as={Form} alignItems='flex-start'>
-            <FormControl>
-              <FormLabel htmlFor='name' isRequired isInvalid={errors.name}>
-                Name of attribute
-              </FormLabel>
+            <FormControl isRequired isInvalid={errors.name}>
+              <FormLabel htmlFor='name'>Name of attribute</FormLabel>
               <Field
                 as={Input}
                 type='text'
@@ -87,6 +85,7 @@ export default function ProfileAttributeForm({
                 id='name'
                 placeholder='Name of the attribute'
                 value={values.name}
+                required
               />
               {errors.name ? (
                 <FormErrorMessage>{errors.name}</FormErrorMessage>
@@ -117,7 +116,7 @@ export default function ProfileAttributeForm({
                 <option value='public'>Public</option>
               </Field>
             </FormControl>
-            <FormControl>
+            <FormControl isRequired>
               <FormLabel>Type:</FormLabel>
               <Field
                 as={Select}
@@ -125,6 +124,8 @@ export default function ProfileAttributeForm({
                 name='key_type'
                 id='key_type'
                 value={values.key_type}
+                isDisabled={values.key_type}
+                placeholder='Select type'
               >
                 <option value='text'>Text</option>
                 <option value='number'>Number</option>

--- a/src/pages/teams/[id]/edit-profiles.js
+++ b/src/pages/teams/[id]/edit-profiles.js
@@ -124,7 +124,7 @@ export default class TeamEditProfile extends Component {
       { key: 'name' },
       { key: 'description' },
       { key: 'visibility' },
-      { key: 'key_type', header: 'type' },
+      { key: 'key_type', label: 'type' },
       { key: 'required' },
       { key: 'actions', render: this.renderActions },
     ]

--- a/src/pages/teams/[id]/edit.js
+++ b/src/pages/teams/[id]/edit.js
@@ -183,6 +183,7 @@ export default class TeamEdit extends Component {
               profileValues={profileValues}
               teamTags={teamAttributes}
               orgTeamTags={orgTeamAttributes}
+              team={team}
               onSubmit={async (values, actions) => {
                 try {
                   let tags = Object.keys(values.tags).map((key) => {


### PR DESCRIPTION
This pr:
- ensures that the correct input type is used for the "edit team" attributes
- adds the org name to the team edit "Org attributes" section
- Prevents modification of attribute key_types on team and member attribute forms once the key type has been set.

Contributes to #264 