### PR TITLE
Prevent invalid user management actions

### DIFF
--- a/src/pages/teams/[id]/index.js
+++ b/src/pages/teams/[id]/index.js
@@ -225,7 +225,7 @@ class Team extends Component {
 
     if (!team) return null
 
-    const userId = this.state.session?.user_id
+    const userId = +this.state.session?.user_id
     const members = map(prop('id'), teamMembers.members)
     const moderators = map(prop('osm_id'), teamMembers.moderators)
 
@@ -260,7 +260,7 @@ class Team extends Component {
             this.addModerator(this.state.profileMeta.id)
           },
         })
-      } else {
+      } else if (moderators.length > 1) {
         profileActions.push({
           name: 'Remove moderator',
           onClick: async () => {


### PR DESCRIPTION
This PR:
- Fixes prevent of self-removal from a team (type coercion error)
- Requires more than 1 moderator to demote own moderator status