### PR TITLE
Add error boundary and update 404 page

### DIFF
--- a/src/components/error-boundary.js
+++ b/src/components/error-boundary.js
@@ -1,0 +1,58 @@
+import { Box, Button, Container, Heading, Text } from '@chakra-ui/react'
+import React from 'react'
+import InpageHeader from './inpage-header'
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props)
+
+    // Define a state variable to track whether is an error or not
+    this.state = { hasError: false }
+  }
+  // eslint-disable-next-line no-unused-vars
+  static getDerivedStateFromError(error) {
+    // Update state so the next render will show the fallback UI
+
+    return { hasError: true }
+  }
+  componentDidCatch(error, errorInfo) {
+    // You can use your own error logging service here
+    // eslint-disable-next-line no-console
+    console.error({ error, errorInfo })
+  }
+  render() {
+    // Check if the error is thrown
+    if (this.state.hasError) {
+      // You can render any custom fallback UI
+      return (
+        <Box as='main' mb={8}>
+          <InpageHeader>
+            <Heading color='white' mb={2}>
+              Application error
+            </Heading>
+          </InpageHeader>
+          <Container maxW='container.xl' as='section'>
+            <Box layerStyle={'shadowed'}>
+              <Text fontSize='2xl'>
+                Sorry, there was an error loading this page
+              </Text>
+              <Button onClick={() => this.setState({ hasError: false })}>
+                Try again?
+              </Button>
+              <Text>
+                Still having problems? Try logging out and back in or contacting
+                a system administrator.
+              </Text>
+            </Box>
+          </Container>
+        </Box>
+      )
+    }
+
+    // Return children components in case of no error
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/src/components/profile-form.js
+++ b/src/components/profile-form.js
@@ -158,6 +158,7 @@ export default class ProfileForm extends Component {
       this.setState({
         error: e,
         loading: false,
+        returnUrl: '/',
       })
     }
   }
@@ -172,6 +173,7 @@ export default class ProfileForm extends Component {
       returnUrl,
       consentChecked,
       loading,
+      error,
     } = this.state
     profileValues = profileValues || {}
 
@@ -180,6 +182,21 @@ export default class ProfileForm extends Component {
         <Box as='main' mb={16}>
           <InpageHeader>
             <Heading color='white'>Loading...</Heading>
+          </InpageHeader>
+        </Box>
+      )
+    }
+    if (error) {
+      return (
+        <Box as='main' mb={16}>
+          <InpageHeader>
+            <Heading color='white'>Error loading team...</Heading>
+            <Text py={4}>
+              This team can not be loaded, or you don&apos;t have permission to
+              access this team. Contact the team moderator to ensure you have
+              the correct permissions.
+            </Text>
+            <Link href='/dashboard'>← Return to your dashboard</Link>
           </InpageHeader>
         </Box>
       )

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -8,7 +8,7 @@ export default class UhOh extends Component {
       <Box as='main' mb={8}>
         <InpageHeader>
           <Heading color='white' mb={2}>
-            Page Not Found
+            404 - Page Not Found
           </Heading>
         </InpageHeader>
         <Container maxW='container.xl' as='section'>

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -12,6 +12,7 @@ import { SessionProvider } from 'next-auth/react'
 
 import theme from '../styles/theme'
 import PageHeader from '../components/page-header'
+import ErrorBoundary from '../components/error-boundary'
 const BASE_PATH = process.env.BASE_PATH || ''
 
 export default function App({
@@ -35,7 +36,9 @@ export default function App({
           padding='0'
         >
           <PageHeader />
-          <Component {...pageProps} />
+          <ErrorBoundary>
+            <Component {...pageProps} />
+          </ErrorBoundary>
         </Box>
         <ToastContainer position='bottom-right' />
       </SessionProvider>

--- a/src/pages/uh-oh.js
+++ b/src/pages/uh-oh.js
@@ -1,17 +1,28 @@
 import React, { Component } from 'react'
+import { Box, Container, Heading, Text } from '@chakra-ui/react'
+import InpageHeader from '../components/inpage-header'
 
 export default class UhOh extends Component {
   render() {
     return (
-      <article className='inner page'>
-        <h1>Page not found</h1>
-        <div>Sorry, the page you are looking for is not available.</div>
-        <br />
-        <div>
-          Still having problems? Try logging out and back in or contacting a
-          system administrator.
-        </div>
-      </article>
+      <Box as='main' mb={8}>
+        <InpageHeader>
+          <Heading color='white' mb={2}>
+            Page Not Found
+          </Heading>
+        </InpageHeader>
+        <Container maxW='container.xl' as='section'>
+          <Box layerStyle={'shadowed'}>
+            <Text fontSize='2xl'>
+              Sorry, the page you are looking for is not available.
+            </Text>
+            <Text>
+              Still having problems? Try logging out and back in or contacting a
+              system administrator.
+            </Text>
+          </Box>
+        </Container>
+      </Box>
     )
   }
 }


### PR DESCRIPTION
This PR:
- adds a React `ErrorBoundary` around components to catch unhandled errors
- styles and renames the uh-oh 404 page to ensure it is used
- catches errors on the `/teams/:id/profile` edit page

Todo:
- [ ] prompt users to log in when visiting auth-required pages

Contributes to #406 